### PR TITLE
Replace deprecated split function with explode for newer PHP versions

### DIFF
--- a/build/portal/graphs/make-collectd-graphs.sh
+++ b/build/portal/graphs/make-collectd-graphs.sh
@@ -77,7 +77,7 @@ aircraft_message_rate_graph() {
   "LINE1:rate#0000FF:Messages / AC" \
   "LINE1:avgrate#666666:Average:dashes" \
   "GPRINT:avgrate:%3.1lf" \
-  "LINE1:maxrate#FF0000:Maximum:" \
+  "LINE1:maxrate#FF0000:Maximum" \
   "GPRINT:maxrate:%3.1lf\c" \
   "LINE1:aircrafts10#990000:Aircraft Seen / Tracked (RHS) \c" \
   --watermark "Drawn: $nowlit";

--- a/build/portal/graphs/make-collectd-graphs.sh
+++ b/build/portal/graphs/make-collectd-graphs.sh
@@ -582,7 +582,7 @@ range_graph_imperial_nautical(){
   --font "$UNIT_FONT" \
   --font "$LEGEND_FONT" \
   --start end-$4 \
-  --width 428 \
+  --width 480 \
   --height 200 \
   --step "$5" \
   --title "$3 Max Range" \
@@ -614,7 +614,7 @@ range_graph_imperial_statute(){
   --font "$UNIT_FONT" \
   --font "$LEGEND_FONT" \
   --start end-$4 \
-  --width 428 \
+  --width 480 \
   --height 200 \
   --step "$5" \
   --title "$3 Max Range" \
@@ -646,7 +646,7 @@ range_graph_metric() {
   --font "$UNIT_FONT" \
   --font "$LEGEND_FONT" \
   --start end-$4 \
-  --width 428 \
+  --width 480 \
   --height 200 \
   --step "$5" \
   --title "$3 Max Range" \

--- a/build/portal/graphs/make-collectd-graphs.sh
+++ b/build/portal/graphs/make-collectd-graphs.sh
@@ -6,11 +6,23 @@ DOCUMENTROOT=`sed 's/.*"\(.*\)"[^"]*$/\1/' <<< $RAWDOCUMENTROOT`
 
 renice -n 5 -p $$
 
+## FONTSIZE
+TITLE_FONT=TITLE:8:.
+AXIS_FONT=AXIS:7:.
+UNIT_FONT=UNIT:7:.
+LEGEND_FONT=LEGEND:7:.
+
 ## DUMP1090 GRAPHS
 
 aircraft_graph() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 480 \
   --height 200 \
@@ -38,8 +50,14 @@ aircraft_graph() {
 aircraft_message_rate_graph() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
-  --width 428 \
+  --width 480 \
   --height 200 \
   --step "$5" \
   --title "$3 Message Rate / Aircraft" \
@@ -68,6 +86,12 @@ aircraft_message_rate_graph() {
 cpu_graph_dump1090() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 480 \
   --height 200 \
@@ -92,6 +116,12 @@ cpu_graph_dump1090() {
 tracks_graph() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 480 \
   --height 200 \
@@ -115,6 +145,12 @@ tracks_graph() {
 cpu_graph() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 1010 \
   --height 200 \
@@ -153,8 +189,14 @@ cpu_graph() {
 df_root_graph() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
-  --width 496 \
+  --width 480 \
   --height 200 \
   --step "$5" \
   --title "Disk Usage (/)" \
@@ -174,6 +216,12 @@ df_root_graph() {
 disk_io_iops_graph() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 480 \
   --height 200 \
@@ -201,6 +249,12 @@ disk_io_iops_graph() {
 disk_io_octets_graph() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 480 \
   --height 200 \
@@ -228,6 +282,12 @@ disk_io_octets_graph() {
 eth0_graph() {
   rrdtool graph \
   "$1" \
+  --full-size-mode \
+  --imgformat SVG \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 480 \
   --height 200 \
@@ -254,8 +314,14 @@ eth0_graph() {
 memory_graph() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
-  --width 496 \
+  --width 480 \
   --height 200 \
   --step "$5" \
   --lower-limit 0 \
@@ -277,6 +343,12 @@ memory_graph() {
 temp_graph_imperial() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 480 \
   --height 200 \
@@ -300,6 +372,12 @@ temp_graph_imperial() {
 temp_graph_metric() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 480 \
   --height 200 \
@@ -321,6 +399,12 @@ temp_graph_metric() {
 wlan0_graph() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 480 \
   --height 200 \
@@ -349,8 +433,14 @@ wlan0_graph() {
 local_rate_graph() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
-  --width 429 \
+  --width 480 \
   --height 200 \
   --step "$5" \
   --title "$3 Message Rate" \
@@ -373,8 +463,14 @@ local_rate_graph() {
 local_trailing_rate_graph() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
-  --width 959 \
+  --width 1010 \
   --height 200 \
   --step "$5" \
   --title "$3 Message Rate" \
@@ -479,6 +575,12 @@ local_trailing_rate_graph() {
 range_graph_imperial_nautical(){
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 428 \
   --height 200 \
@@ -505,6 +607,12 @@ range_graph_imperial_nautical(){
 range_graph_imperial_statute(){
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 428 \
   --height 200 \
@@ -531,6 +639,12 @@ range_graph_imperial_statute(){
 range_graph_metric() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 428 \
   --height 200 \
@@ -556,9 +670,15 @@ range_graph_metric() {
 signal_graph() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 480 \
-  --height 186 \
+  --height 200 \
   --step "$5" \
   --title "$3 Signal Level" \
   --vertical-label "dBFS" \
@@ -590,6 +710,12 @@ signal_graph() {
 remote_rate_graph() {
   rrdtool graph \
   "$1" \
+  --imgformat SVG \
+  --full-size-mode \
+  --font "$TITLE_FONT" \
+  --font "$AXIS_FONT" \
+  --font "$UNIT_FONT" \
+  --font "$LEGEND_FONT" \
   --start end-$4 \
   --width 480 \
   --height 200 \
@@ -609,39 +735,39 @@ remote_rate_graph() {
 
 
 dump1090_graphs() {
-  aircraft_graph ${DOCUMENTROOT}/graphs/dump1090-$2-aircraft-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-  aircraft_message_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-aircraft_message_rate-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-  cpu_graph_dump1090 ${DOCUMENTROOT}/graphs/dump1090-$2-cpu-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-  tracks_graph ${DOCUMENTROOT}/graphs/dump1090-$2-tracks-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5" 
+  aircraft_graph ${DOCUMENTROOT}/graphs/dump1090-$2-aircraft-$4.svg /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
+  aircraft_message_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-aircraft_message_rate-$4.svg /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
+  cpu_graph_dump1090 ${DOCUMENTROOT}/graphs/dump1090-$2-cpu-$4.svg /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
+  tracks_graph ${DOCUMENTROOT}/graphs/dump1090-$2-tracks-$4.svg /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5" 
 }
 
 system_graphs() {
-  cpu_graph ${DOCUMENTROOT}/graphs/system-$2-cpu-$4.png /var/lib/collectd/rrd/$1/aggregation-cpu-average "$3" "$4" "$5"
-  df_root_graph ${DOCUMENTROOT}/graphs/system-$2-df_root-$4.png /var/lib/collectd/rrd/$1/df-root "$3" "$4" "$5"
-  disk_io_iops_graph ${DOCUMENTROOT}/graphs/system-$2-disk_io_iops-$4.png /var/lib/collectd/rrd/$1/disk-mmcblk0 "$3" "$4" "$5"
-  disk_io_octets_graph ${DOCUMENTROOT}/graphs/system-$2-disk_io_octets-$4.png /var/lib/collectd/rrd/$1/disk-mmcblk0 "$3" "$4" "$5"
-  eth0_graph ${DOCUMENTROOT}/graphs/system-$2-eth0_bandwidth-$4.png /var/lib/collectd/rrd/$1/interface-eth0 "$3" "$4" "$5"
-  memory_graph ${DOCUMENTROOT}/graphs/system-$2-memory-$4.png /var/lib/collectd/rrd/$1/memory "$3" "$4" "$5"
-  temp_graph_imperial ${DOCUMENTROOT}/graphs/system-$2-temperature_imperial-$4.png /var/lib/collectd/rrd/$1/table-$2 "$3" "$4" "$5"
-  temp_graph_metric ${DOCUMENTROOT}/graphs/system-$2-temperature_metric-$4.png /var/lib/collectd/rrd/$1/table-$2 "$3" "$4" "$5"
-  wlan0_graph ${DOCUMENTROOT}/graphs/system-$2-wlan0_bandwidth-$4.png /var/lib/collectd/rrd/$1/interface-wlan0 "$3" "$4" "$5"
+  cpu_graph ${DOCUMENTROOT}/graphs/system-$2-cpu-$4.svg /var/lib/collectd/rrd/$1/aggregation-cpu-average "$3" "$4" "$5"
+  df_root_graph ${DOCUMENTROOT}/graphs/system-$2-df_root-$4.svg /var/lib/collectd/rrd/$1/df-root "$3" "$4" "$5"
+  disk_io_iops_graph ${DOCUMENTROOT}/graphs/system-$2-disk_io_iops-$4.svg /var/lib/collectd/rrd/$1/disk-mmcblk0 "$3" "$4" "$5"
+  disk_io_octets_graph ${DOCUMENTROOT}/graphs/system-$2-disk_io_octets-$4.svg /var/lib/collectd/rrd/$1/disk-mmcblk0 "$3" "$4" "$5"
+  eth0_graph ${DOCUMENTROOT}/graphs/system-$2-eth0_bandwidth-$4.svg /var/lib/collectd/rrd/$1/interface-eth0 "$3" "$4" "$5"
+  memory_graph ${DOCUMENTROOT}/graphs/system-$2-memory-$4.svg /var/lib/collectd/rrd/$1/memory "$3" "$4" "$5"
+  temp_graph_imperial ${DOCUMENTROOT}/graphs/system-$2-temperature_imperial-$4.svg /var/lib/collectd/rrd/$1/table-$2 "$3" "$4" "$5"
+  temp_graph_metric ${DOCUMENTROOT}/graphs/system-$2-temperature_metric-$4.svg /var/lib/collectd/rrd/$1/table-$2 "$3" "$4" "$5"
+  wlan0_graph ${DOCUMENTROOT}/graphs/system-$2-wlan0_bandwidth-$4.svg /var/lib/collectd/rrd/$1/interface-wlan0 "$3" "$4" "$5"
 }
 
 dump1090_receiver_graphs() {
   dump1090_graphs "$1" "$2" "$3" "$4" "$5"
   system_graphs "$1" "$2" "$3" "$4" "$5"
-  local_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-local_rate-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-  local_trailing_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-local_trailing_rate-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-  range_graph_imperial_nautical ${DOCUMENTROOT}/graphs/dump1090-$2-range_imperial_nautical-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-  range_graph_imperial_statute ${DOCUMENTROOT}/graphs/dump1090-$2-range_imperial_statute-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-  range_graph_metric ${DOCUMENTROOT}/graphs/dump1090-$2-range_metric-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
-  signal_graph ${DOCUMENTROOT}/graphs/dump1090-$2-signal-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
+  local_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-local_rate-$4.svg /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
+  local_trailing_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-local_trailing_rate-$4.svg /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
+  range_graph_imperial_nautical ${DOCUMENTROOT}/graphs/dump1090-$2-range_imperial_nautical-$4.svg /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
+  range_graph_imperial_statute ${DOCUMENTROOT}/graphs/dump1090-$2-range_imperial_statute-$4.svg /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
+  range_graph_metric ${DOCUMENTROOT}/graphs/dump1090-$2-range_metric-$4.svg /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
+  signal_graph ${DOCUMENTROOT}/graphs/dump1090-$2-signal-$4.svg /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
 }
 
 dump1090_hub_graphs() {
   dump1090_graphs "$1" "$2" "$3" "$4" "$5"
   system_graphs "$1" "$2" "$3" "$4" "$5"
-  remote_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-remote_rate-$4.png /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
+  remote_rate_graph ${DOCUMENTROOT}/graphs/dump1090-$2-remote_rate-$4.svg /var/lib/collectd/rrd/$1/dump1090-$2 "$3" "$4" "$5"
 }
 
 period="$1"

--- a/build/portal/html/api/system.php
+++ b/build/portal/html/api/system.php
@@ -133,7 +133,7 @@
     }
 
     function getUptimeInformation() {
-        $uptimeArray = split(' ', exec("cat /proc/uptime"));
+        $uptimeArray = explode(' ', exec("cat /proc/uptime"));
         $uptime['inSeconds'] = trim($uptimeArray[0]);
         $uptime['hours'] = floor($uptime['inSeconds'] / 3600);
         $uptime['minutes'] = floor(($uptime['inSeconds'] - ($uptime['hours'] * 3600)) / 60);

--- a/build/portal/html/templates/default/assets/js/graphs.js
+++ b/build/portal/html/templates/default/assets/js/graphs.js
@@ -34,81 +34,81 @@ function switchView(newTimeFrame) {
 
     // Display images for the requested time frame and create links to full sized images for the requested time frame.
     var element;
-    $("#dump1090-local_trailing_rate-image").attr("src", "graphs/dump1090-" + $hostName + "-local_trailing_rate-" + $timeFrame + ".png?time=" + $timestamp);
-    $("#dump1090-local_trailing_rate-link").attr("href", "graphs/dump1090-" + $hostName + "-local_trailing_rate-" + $timeFrame + ".png?time=" + $timestamp);
+    $("#dump1090-local_trailing_rate-image").attr("src", "graphs/dump1090-" + $hostName + "-local_trailing_rate-" + $timeFrame + ".svg?time=" + $timestamp);
+    $("#dump1090-local_trailing_rate-link").attr("href", "graphs/dump1090-" + $hostName + "-local_trailing_rate-" + $timeFrame + ".svg?time=" + $timestamp);
 
-    $("#dump1090-local_rate-image").attr("src", "graphs/dump1090-" + $hostName + "-local_rate-" + $timeFrame + ".png?time=" + $timestamp);
-    $("#dump1090-local_rate-link").attr("href", "graphs/dump1090-" + $hostName + "-local_rate-" + $timeFrame + ".png?time=" + $timestamp);
+    $("#dump1090-local_rate-image").attr("src", "graphs/dump1090-" + $hostName + "-local_rate-" + $timeFrame + ".svg?time=" + $timestamp);
+    $("#dump1090-local_rate-link").attr("href", "graphs/dump1090-" + $hostName + "-local_rate-" + $timeFrame + ".svg?time=" + $timestamp);
 
-    $("#dump1090-aircraft_message_rate-image").attr("src", "graphs/dump1090-" + $hostName + "-aircraft_message_rate-" + $timeFrame + ".png?time=" + $timestamp);
-    $("#dump1090-aircraft_message_rate-link").attr("href", "graphs/dump1090-" + $hostName + "-aircraft_message_rate-" + $timeFrame + ".png?time=" + $timestamp);
+    $("#dump1090-aircraft_message_rate-image").attr("src", "graphs/dump1090-" + $hostName + "-aircraft_message_rate-" + $timeFrame + ".svg?time=" + $timestamp);
+    $("#dump1090-aircraft_message_rate-link").attr("href", "graphs/dump1090-" + $hostName + "-aircraft_message_rate-" + $timeFrame + ".svg?time=" + $timestamp);
 
-    $("#dump1090-aircraft-image").attr("src", "graphs/dump1090-" + $hostName + "-aircraft-" + $timeFrame + ".png?time=" + $timestamp);
-    $("#dump1090-aircraft-link").attr("href", "graphs/dump1090-" + $hostName + "-aircraft-" + $timeFrame + ".png?time=" + $timestamp);
+    $("#dump1090-aircraft-image").attr("src", "graphs/dump1090-" + $hostName + "-aircraft-" + $timeFrame + ".svg?time=" + $timestamp);
+    $("#dump1090-aircraft-link").attr("href", "graphs/dump1090-" + $hostName + "-aircraft-" + $timeFrame + ".svg?time=" + $timestamp);
 
-    $("#dump1090-tracks-image").attr("src", "graphs/dump1090-" + $hostName + "-tracks-" + $timeFrame + ".png?time=" + $timestamp);
-    $("#dump1090-tracks-link").attr("href", "graphs/dump1090-" + $hostName + "-tracks-" + $timeFrame + ".png?time=" + $timestamp);
+    $("#dump1090-tracks-image").attr("src", "graphs/dump1090-" + $hostName + "-tracks-" + $timeFrame + ".svg?time=" + $timestamp);
+    $("#dump1090-tracks-link").attr("href", "graphs/dump1090-" + $hostName + "-tracks-" + $timeFrame + ".svg?time=" + $timestamp);
 
     element =  document.getElementById('dump1090-range_imperial_nautical-image');
     if (typeof(element) != 'undefined' && element != null) {
-        $("#dump1090-range_imperial_nautical-image").attr("src", "graphs/dump1090-" + $hostName + "-range_imperial_nautical-" + $timeFrame + ".png?time=" + $timestamp);
-        $("#dump1090-range_imperial_nautical-link").attr("href", "graphs/dump1090-" + $hostName + "-range_imperial_nautical-" + $timeFrame + ".png?time=" + $timestamp);
+        $("#dump1090-range_imperial_nautical-image").attr("src", "graphs/dump1090-" + $hostName + "-range_imperial_nautical-" + $timeFrame + ".svg?time=" + $timestamp);
+        $("#dump1090-range_imperial_nautical-link").attr("href", "graphs/dump1090-" + $hostName + "-range_imperial_nautical-" + $timeFrame + ".svg?time=" + $timestamp);
     }
 
     element =  document.getElementById('dump1090-range_imperial_statute-image');
     if (typeof(element) != 'undefined' && element != null) {
-        $("#dump1090-range_imperial_statute-image").attr("src", "graphs/dump1090-" + $hostName + "-range_imperial_statute-" + $timeFrame + ".png?time=" + $timestamp);
-        $("#dump1090-range_imperial_statute-link").attr("href", "graphs/dump1090-" + $hostName + "-range_imperial_statute-" + $timeFrame + ".png?time=" + $timestamp);
+        $("#dump1090-range_imperial_statute-image").attr("src", "graphs/dump1090-" + $hostName + "-range_imperial_statute-" + $timeFrame + ".svg?time=" + $timestamp);
+        $("#dump1090-range_imperial_statute-link").attr("href", "graphs/dump1090-" + $hostName + "-range_imperial_statute-" + $timeFrame + ".svg?time=" + $timestamp);
     }
 
     element =  document.getElementById('dump1090-range_metric-image');
     if (typeof(element) != 'undefined' && element != null) {
-        $("#dump1090-range_metric-image").attr("src", "graphs/dump1090-" + $hostName + "-range_metric-" + $timeFrame + ".png?time=" + $timestamp);
-        $("#dump1090-range_metric-link").attr("href", "graphs/dump1090-" + $hostName + "-range_metric-" + $timeFrame + ".png?time=" + $timestamp);
+        $("#dump1090-range_metric-image").attr("src", "graphs/dump1090-" + $hostName + "-range_metric-" + $timeFrame + ".svg?time=" + $timestamp);
+        $("#dump1090-range_metric-link").attr("href", "graphs/dump1090-" + $hostName + "-range_metric-" + $timeFrame + ".svg?time=" + $timestamp);
     }
 
-    $("#dump1090-signal-image").attr("src", "graphs/dump1090-" + $hostName + "-signal-" + $timeFrame + ".png?time=" + $timestamp);
-    $("#dump1090-signal-link").attr("href", "graphs/dump1090-" + $hostName + "-signal-" + $timeFrame + ".png?time=" + $timestamp);
+    $("#dump1090-signal-image").attr("src", "graphs/dump1090-" + $hostName + "-signal-" + $timeFrame + ".svg?time=" + $timestamp);
+    $("#dump1090-signal-link").attr("href", "graphs/dump1090-" + $hostName + "-signal-" + $timeFrame + ".svg?time=" + $timestamp);
 
-    $("#dump1090-cpu-image").attr("src", "graphs/dump1090-" + $hostName + "-cpu-" + $timeFrame + ".png?time=" + $timestamp);
-    $("#dump1090-cpu-link").attr("href", "graphs/dump1090-" + $hostName + "-cpu-" + $timeFrame + ".png?time=" + $timestamp);
+    $("#dump1090-cpu-image").attr("src", "graphs/dump1090-" + $hostName + "-cpu-" + $timeFrame + ".svg?time=" + $timestamp);
+    $("#dump1090-cpu-link").attr("href", "graphs/dump1090-" + $hostName + "-cpu-" + $timeFrame + ".svg?time=" + $timestamp);
 
-    $("#system-cpu-image").attr("src", "graphs/system-" + $hostName + "-cpu-" + $timeFrame + ".png?time=" + $timestamp);
-    $("#system-cpu-link").attr("href", "graphs/system-" + $hostName + "-cpu-" + $timeFrame + ".png?time=" + $timestamp);
+    $("#system-cpu-image").attr("src", "graphs/system-" + $hostName + "-cpu-" + $timeFrame + ".svg?time=" + $timestamp);
+    $("#system-cpu-link").attr("href", "graphs/system-" + $hostName + "-cpu-" + $timeFrame + ".svg?time=" + $timestamp);
 
     element =  document.getElementById('system-eth0_bandwidth-image');
     if (typeof(element) != 'undefined' && element != null) {
-        $("#system-eth0_bandwidth-image").attr("src", "graphs/system-" + $hostName + "-eth0_bandwidth-" + $timeFrame + ".png?time=" + $timestamp);
-        $("#system-eth0_bandwidth-link").attr("href", "graphs/system-" + $hostName + "-eth0_bandwidth-" + $timeFrame + ".png?time=" + $timestamp);
+        $("#system-eth0_bandwidth-image").attr("src", "graphs/system-" + $hostName + "-eth0_bandwidth-" + $timeFrame + ".svg?time=" + $timestamp);
+        $("#system-eth0_bandwidth-link").attr("href", "graphs/system-" + $hostName + "-eth0_bandwidth-" + $timeFrame + ".svg?time=" + $timestamp);
     }
     element =  document.getElementById('system-wlan0_bandwidth-image');
     if (typeof(element) != 'undefined' && element != null) {
-        $("#system-wlan0_bandwidth-image").attr("src", "graphs/system-" + $hostName + "-wlan0_bandwidth-" + $timeFrame + ".png?time=" + $timestamp);
-        $("#system-wlan0_bandwidth-link").attr("href", "graphs/system-" + $hostName + "-wlan0_bandwidth-" + $timeFrame + ".png?time=" + $timestamp);
+        $("#system-wlan0_bandwidth-image").attr("src", "graphs/system-" + $hostName + "-wlan0_bandwidth-" + $timeFrame + ".svg?time=" + $timestamp);
+        $("#system-wlan0_bandwidth-link").attr("href", "graphs/system-" + $hostName + "-wlan0_bandwidth-" + $timeFrame + ".svg?time=" + $timestamp);
     }
     
-    $("#system-memory-image").attr("src", "graphs/system-" + $hostName + "-memory-" + $timeFrame + ".png?time=" + $timestamp);
-    $("#system-memory-link").attr("href", "graphs/system-" + $hostName + "-memory-" + $timeFrame + ".png?time=" + $timestamp);
+    $("#system-memory-image").attr("src", "graphs/system-" + $hostName + "-memory-" + $timeFrame + ".svg?time=" + $timestamp);
+    $("#system-memory-link").attr("href", "graphs/system-" + $hostName + "-memory-" + $timeFrame + ".svg?time=" + $timestamp);
 
     element =  document.getElementById('system-temperature_imperial-image');
     if (typeof(element) != 'undefined' && element != null) {
-        $("#system-temperature_imperial-image").attr("src", "graphs/system-" + $hostName + "-temperature_imperial-" + $timeFrame + ".png?time=" + $timestamp);
-        $("#system-temperature_imperial-link").attr("href", "graphs/system-" + $hostName + "-temperature_imperial-" + $timeFrame + ".png?time=" + $timestamp);
+        $("#system-temperature_imperial-image").attr("src", "graphs/system-" + $hostName + "-temperature_imperial-" + $timeFrame + ".svg?time=" + $timestamp);
+        $("#system-temperature_imperial-link").attr("href", "graphs/system-" + $hostName + "-temperature_imperial-" + $timeFrame + ".svg?time=" + $timestamp);
     }
     element =  document.getElementById('system-temperature_metric-image');
     if (typeof(element) != 'undefined' && element != null) {
-        $("#system-temperature_metric-image").attr("src", "graphs/system-" + $hostName + "-temperature_metric-" + $timeFrame + ".png?time=" + $timestamp);
-        $("#system-temperature_metric-link").attr("href", "graphs/system-" + $hostName + "-temperature_metric-" + $timeFrame + ".png?time=" + $timestamp);
+        $("#system-temperature_metric-image").attr("src", "graphs/system-" + $hostName + "-temperature_metric-" + $timeFrame + ".svg?time=" + $timestamp);
+        $("#system-temperature_metric-link").attr("href", "graphs/system-" + $hostName + "-temperature_metric-" + $timeFrame + ".svg?time=" + $timestamp);
     }
 
-    $("#system-df_root-image").attr("src", "graphs/system-" + $hostName + "-df_root-" + $timeFrame + ".png?time=" + $timestamp);
-    $("#system-df_root-link").attr("href", "graphs/system-" + $hostName + "-df_root-" + $timeFrame + ".png?time=" + $timestamp);
+    $("#system-df_root-image").attr("src", "graphs/system-" + $hostName + "-df_root-" + $timeFrame + ".svg?time=" + $timestamp);
+    $("#system-df_root-link").attr("href", "graphs/system-" + $hostName + "-df_root-" + $timeFrame + ".svg?time=" + $timestamp);
 
-    $("#system-disk_io_iops-image").attr("src", "graphs/system-" + $hostName + "-disk_io_iops-" + $timeFrame + ".png?time=" + $timestamp);
-    $("#system-disk_io_iops-link").attr("href", "graphs/system-" + $hostName + "-disk_io_iops-" + $timeFrame + ".png?time=" + $timestamp);
+    $("#system-disk_io_iops-image").attr("src", "graphs/system-" + $hostName + "-disk_io_iops-" + $timeFrame + ".svg?time=" + $timestamp);
+    $("#system-disk_io_iops-link").attr("href", "graphs/system-" + $hostName + "-disk_io_iops-" + $timeFrame + ".svg?time=" + $timestamp);
 
-    $("#system-disk_io_octets-image").attr("src", "graphs/system-" + $hostName + "-disk_io_octets-" + $timeFrame + ".png?time=" + $timestamp);
-    $("#system-disk_io_octets-link").attr("href", "graphs/system-" + $hostName + "-disk_io_octets-" + $timeFrame + ".png?time=" + $timestamp);
+    $("#system-disk_io_octets-image").attr("src", "graphs/system-" + $hostName + "-disk_io_octets-" + $timeFrame + ".svg?time=" + $timestamp);
+    $("#system-disk_io_octets-link").attr("href", "graphs/system-" + $hostName + "-disk_io_octets-" + $timeFrame + ".svg?time=" + $timestamp);
 
 	// Set the button related to the selected time frame to active.
     $("#btn-1h").removeClass('active');

--- a/systemd/ads-b-graphs-1h.service
+++ b/systemd/ads-b-graphs-1h.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=ADS-B Graphs 1h
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/make-collectd-graphs.sh 1h

--- a/systemd/ads-b-graphs-1h.timer
+++ b/systemd/ads-b-graphs-1h.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=ADS-B Graphs 1h
+
+[Timer]
+OnBootSec=10
+OnCalendar=*:0/10
+RandomizedDelaySec=60
+
+[Install]
+WantedBy=timers.target

--- a/systemd/ads-b-graphs-24h.service
+++ b/systemd/ads-b-graphs-24h.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=ADS-B Graphs 24h
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/make-collectd-graphs.sh 24h

--- a/systemd/ads-b-graphs-24h.timer
+++ b/systemd/ads-b-graphs-24h.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=ADS-B Graphs 24h
+
+[Timer]
+OnBootSec=10
+OnCalendar=*:0/30
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target

--- a/systemd/ads-b-graphs-30d.service
+++ b/systemd/ads-b-graphs-30d.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=ADS-B Graphs 30d
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/make-collectd-graphs.sh 30d

--- a/systemd/ads-b-graphs-30d.timer
+++ b/systemd/ads-b-graphs-30d.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=ADS-B Graphs 30d
+
+[Timer]
+OnBootSec=10
+OnCalendar=*-*-* 00:00:00
+RandomizedDelaySec=600
+
+[Install]
+WantedBy=timers.target

--- a/systemd/ads-b-graphs-365d.service
+++ b/systemd/ads-b-graphs-365d.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=ADS-B Graphs 365d
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/make-collectd-graphs.sh 365d

--- a/systemd/ads-b-graphs-365d.timer
+++ b/systemd/ads-b-graphs-365d.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=ADS-B Graphs 365d
+
+[Timer]
+OnBootSec=10
+OnCalendar=Mon *-*-* 00:00:00
+RandomizedDelaySec=1200
+
+[Install]
+WantedBy=timers.target

--- a/systemd/ads-b-graphs-6h.service
+++ b/systemd/ads-b-graphs-6h.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=ADS-B Graphs 6h
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/make-collectd-graphs.sh 6h

--- a/systemd/ads-b-graphs-6h.timer
+++ b/systemd/ads-b-graphs-6h.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=ADS-B Graphs 6h
+
+[Timer]
+OnBootSec=10
+OnCalendar=*:0/15
+RandomizedDelaySec=120
+
+[Install]
+WantedBy=timers.target

--- a/systemd/ads-b-graphs-7d.service
+++ b/systemd/ads-b-graphs-7d.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=ADS-B Graphs 7d
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/make-collectd-graphs.sh 7d

--- a/systemd/ads-b-graphs-7d.timer
+++ b/systemd/ads-b-graphs-7d.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=ADS-B Graphs 7d
+
+[Timer]
+OnBootSec=10
+OnCalendar=*-*-* *:00:00
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
The split function was dropped with the introduction of PHP7 and marked deprecated as of PHP version 5.3.0. Replacing it with the explode function should be of no harm and will make adsb-receiver work with PHP7.