### PR TITLE
Read history files instead of aircraft.json upon notification of file

### DIFF
--- a/bash/portal/install.sh
+++ b/bash/portal/install.sh
@@ -326,6 +326,11 @@ EOF
                  ;;
         esac
 
+        # Add Python requirements
+        sudo apt-get -y update
+        sudo apt-get -y install python-pip
+        sudo pip install inotify
+
         # Create and set permissions on the flight logging maintainance script.
         PYTHONPATH=`which python`
         tee $BUILDDIR/portal/logging/flights-maint.sh > /dev/null <<EOF

--- a/build/portal/html/install/index.php
+++ b/build/portal/html/install/index.php
@@ -324,6 +324,14 @@ EOF;
                     break;
                 }
 
+                // Indexes (common syntax)
+                $indexPositionsSql = 'CREATE INDEX '.$dbPrefix.'positions_message_flight_idx
+                                      ON '.$dbPrefix.'positions (flight, message DESC);';
+                $indexFlightsSql = 'CREATE UNIQUE INDEX '.$dbPrefix.'flights_flight_key
+                                    ON '.$dbPrefix.'flights (flight);';
+                $indexAircratSql = 'CREATE UNIQUE INDEX '.$dbPrefix.'aircraft_icao_key
+                                    ON '.$dbPrefix.'aircraft (icao);';
+
                 $dbh = $common->pdoOpen();
 
                 $sth = $dbh->prepare($administratorsSql);
@@ -351,6 +359,18 @@ EOF;
                 $sth = NULL;
 
                 $sth = $dbh->prepare($settingsSql);
+                $sth->execute();
+                $sth = NULL;
+
+                $sth = $dbh->prepare($indexPositionsSql);
+                $sth->execute();
+                $sth = NULL;
+
+                $sth = $dbh->prepare($indexFlightsSql);
+                $sth->execute();
+                $sth = NULL;
+
+                $sth = $dbh->prepare($indexAircratSql);
                 $sth->execute();
                 $sth = NULL;
 

--- a/build/portal/logging/flights.py
+++ b/build/portal/logging/flights.py
@@ -36,7 +36,9 @@
 # 3) Update the last time the flight was seen.
 
 import datetime
+import inotify.adapters
 import json
+import re
 import time
 import os
 #import urllib2
@@ -178,17 +180,25 @@ class FlightsProcessor(object):
 if __name__ == "__main__":
     processor = FlightsProcessor(config)
 
+    mutability_dir = '/run/dump1090-mutability/'
+    i = inotify.adapters.Inotify()
+    i.add_watch(mutability_dir)
+
     # Main run loop
-    while True:
-        # Read dump1090-mutability's aircraft.json.
-        with open('/run/dump1090-mutability/aircraft.json') as data_file:
-            data = json.load(data_file)
-        # For testing using a remote JSON feed.
-        #response = urllib2.urlopen('http://192.168.254.2/dump1090/data/aircraft.json')
-        #data = json.load(response)
+    for event in i.event_gen():
+        if event is not None:
+            (header, type_names, watch_path, filename) = event
+            if 'IN_MOVED_TO' in type_names and re.match('^history_\d+\.json$', filename):
 
-        processor.processAircraftList(data["aircraft"])
+                # Read dump1090-mutability's aircraft.json.
+                #with open('/run/dump1090-mutability/aircraft.json') as data_file:
+                with open(mutability_dir + filename) as data_file:
+                    data = json.load(data_file)
+                # For testing using a remote JSON feed.
+                #response = urllib2.urlopen('http://192.168.254.2/dump1090/data/aircraft.json')
+                #data = json.load(response)
 
-        log("Last Run: " + datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S")) 
-        time.sleep(15)
+                processor.processAircraftList(data["aircraft"])
+
+                log("Last Run: " + datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S")) 
 

--- a/build/portal/logging/flights.py
+++ b/build/portal/logging/flights.py
@@ -37,6 +37,7 @@
 
 import datetime
 import inotify.adapters
+from  inotify.constants import IN_MOVED_TO
 import json
 import re
 import time
@@ -182,7 +183,7 @@ if __name__ == "__main__":
 
     mutability_dir = '/run/dump1090-mutability/'
     i = inotify.adapters.Inotify()
-    i.add_watch(mutability_dir)
+    i.add_watch(mutability_dir, IN_MOVED_TO)
 
     # Main run loop
     for event in i.event_gen():


### PR DESCRIPTION
creation from the kernel. This is more efficiant than polling and
appears to occur exactly every 30 seconds.

### _Do Not Merge_
This change requires the setup script to install the PyInotify package (https://github.com/dsoprea/PyInotify). I'm not sure how you want to handle this.. `pip`, source, or otherwise. I installed via:
```
sudo apt-get install python-pip
sudo pip install notify
```

### Notes
The script watches the logging directory and receives events from the operating system when anything happens. It ignores all events except "file moved to" which lets us know that some file was moved to the given file name. Based on observation, dump1090-mutability writes a new `history_XXX` file every 30 seconds. It doesn't actually rename `aircraft.json`, but rather appears to writes the history file using an "atomic write" procedure (i.e. writes to a temp file like `history_XXX.json.23abc5` and then renames that to `history_XXX.json`. I watch for this operation. A further safety optimization could be to check specifically for the "file moved from" event, and check that it is actually a history temp file – but I think that is overkill...