### PR TITLE
Add verbose flag and make the press enter to continue prompts optional…

### DIFF
--- a/bash/decoders/dump1090-fa.sh
+++ b/bash/decoders/dump1090-fa.sh
@@ -61,7 +61,9 @@ if [ $CONTINUESETUP = 1 ]; then
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  Dump1090-fa setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -139,7 +141,9 @@ if [ $(dpkg-query -W -f='${STATUS}' dump1090-fa 2>/dev/null | grep -c "ok instal
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  Dump1090-fa setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -191,6 +195,8 @@ echo ""
 echo -e "\e[93m----------------------------------------------------------------------------------------------------"
 echo -e "\e[92m  Dump1090-fa setup is complete.\e[39m"
 echo ""
-read -p "Press enter to continue..." CONTINUE
+if [ ${VERBOSE} ] ; then
+    read -p "Press enter to continue..." CONTINUE
+fi
 
 exit 0

--- a/bash/decoders/dump1090-mutability.sh
+++ b/bash/decoders/dump1090-mutability.sh
@@ -61,7 +61,9 @@ if [ $CONTINUESETUP = 1 ]; then
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  Dump1090-mutability setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -137,7 +139,9 @@ if [ $(dpkg-query -W -f='${STATUS}' dump1090-mutability 2>/dev/null | grep -c "o
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  Dump1090-mutability setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -239,6 +243,8 @@ echo ""
 echo -e "\e[93m----------------------------------------------------------------------------------------------------"
 echo -e "\e[92m  Dump1090-mutability setup is complete.\e[39m"
 echo ""
-read -p "Press enter to continue..." CONTINUE
+if [ ${VERBOSE} ] ; then
+    read -p "Press enter to continue..." CONTINUE
+fi
 
 exit 0

--- a/bash/decoders/dump978.sh
+++ b/bash/decoders/dump978.sh
@@ -61,7 +61,9 @@ if [ $CONTINUESETUP = 1 ]; then
     echo -e "\e[93m-------------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  Dump978 setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -126,7 +128,9 @@ if [ ! -f $DUMP978BUILDDIRECTORY/dump978 ] || [ ! -f $DUMP978BUILDDIRECTORY/uat2
     echo -e "\e[93m-------------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  Dump978 setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -255,6 +259,8 @@ echo ""
 echo -e "\e[93m-------------------------------------------------------------------------------------------------------"
 echo -e "\e[92m  Dump978 setup is complete.\e[39m"
 echo ""
-read -p "Press enter to continue..." CONTINUE
+if [ ${VERBOSE} ] ; then
+    read -p "Press enter to continue..." CONTINUE
+fi
 
 exit 0

--- a/bash/decoders/rtlsdr-ogn.sh
+++ b/bash/decoders/rtlsdr-ogn.sh
@@ -43,7 +43,9 @@ echo -e "\033[31mBEFORE CONTINUING:\033[33m"
 echo "RTLSDR-OGN requires it's own dedicated dongle."
 echo ""
 echo -e "\033[37m"
-read -p "Press enter to continue..." CONTINUE
+if [ ${VERBOSE} ] ; then
+    read -p "Press enter to continue..." CONTINUE
+fi
 
 ## CHECK FOR PREREQUISITE PACKAGES
 

--- a/bash/extras/abovetustin.sh
+++ b/bash/extras/abovetustin.sh
@@ -60,7 +60,9 @@ if [ $CONTINUESETUP = 1 ]; then
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  AboveTustin setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -99,7 +101,9 @@ else
             echo -e "\e[93m----------------------------------------------------------------------------------------------------"
             echo -e "\e[92m  AboveTustin setup halted.\e[39m"
             echo ""
-            read -p "Press enter to continue..." CONTINUE
+            if [ ${VERBOSE} ] ; then
+                read -p "Press enter to continue..." CONTINUE
+            fi
             exit 1
         fi
         echo -e "\e[94m  Will attempt to build the PhantomJS binary from source...\e[97m"
@@ -118,7 +122,9 @@ if [ $CONTINUESETUP = 1 ]; then
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  AboveTustin setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -321,7 +327,9 @@ if [ $PHANTOMJSEXISTS = "false" ]; then
             echo -e "\e[93m-------------------------------------------------------------------------------------------------------"
             echo -e "\e[92m  AboveTustin setup halted.\e[39m"
             echo ""
-            read -p "Press enter to continue..." CONTINUE
+            if [ ${VERBOSE} ] ; then
+                read -p "Press enter to continue..." CONTINUE
+            fi
             exit 1
         fi
 
@@ -462,6 +470,8 @@ echo ""
 echo -e "\e[93m----------------------------------------------------------------------------------------------------"
 echo -e "\e[92m  OverTustin setup is complete.\e[39m"
 echo ""
-read -p "Press enter to continue..." CONTINUE
+if [ ${VERBOSE} ] ; then
+    read -p "Press enter to continue..." CONTINUE
+fi
 
 exit 0

--- a/bash/feeders/adsbexchange.sh
+++ b/bash/feeders/adsbexchange.sh
@@ -62,7 +62,9 @@ if [ $CONTINUESETUP = 1 ]; then
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  ADS-B Exchange feed setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -153,7 +155,9 @@ if [ $(dpkg-query -W -f='${STATUS}' mlat-client 2>/dev/null | grep -c "ok instal
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  ADS-B Exchange feed setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -276,6 +280,8 @@ echo ""
 echo -e "\e[93m-------------------------------------------------------------------------------------------------------"
 echo -e "\e[92m  ADS-B Exchange feed setup is complete.\e[39m"
 echo ""
-read -p "Press enter to continue..." CONTINUE
+if [ ${VERBOSE} ] ; then
+    read -p "Press enter to continue..." CONTINUE
+fi
 
 exit 0

--- a/bash/feeders/flightradar24.sh
+++ b/bash/feeders/flightradar24.sh
@@ -61,7 +61,9 @@ if [ $CONTINUESETUP = 1 ]; then
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  Flightradar24 feeder client setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -146,7 +148,9 @@ else
         echo -e "\e[93m----------------------------------------------------------------------------------------------------"
         echo -e "\e[92m  Flightradar24 feeder client setup halted.\e[39m"
         echo ""
-        read -p "Press enter to continue..." CONTINUE
+        if [ ${VERBOSE} ] ; then
+            read -p "Press enter to continue..." CONTINUE
+        fi
         exit 1
     fi
 fi
@@ -161,6 +165,8 @@ echo ""
 echo -e "\e[93m-------------------------------------------------------------------------------------------------------"
 echo -e "\e[92m  Flightradar24 feeder client setup is complete.\e[39m"
 echo ""
-read -p "Press enter to continue..." CONTINUE
+if [ ${VERBOSE} ] ; then
+    read -p "Press enter to continue..." CONTINUE
+fi
 
 exit 0

--- a/bash/feeders/piaware.sh
+++ b/bash/feeders/piaware.sh
@@ -61,7 +61,9 @@ if [ $CONTINUESETUP = 1 ]; then
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  Dump1090-mutability setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -143,7 +145,9 @@ if [ $(dpkg-query -W -f='${STATUS}' piaware 2>/dev/null | grep -c "ok installed"
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  PiAware setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -215,6 +219,8 @@ echo ""
 echo -e "\e[93m-------------------------------------------------------------------------------------------------------"
 echo -e "\e[92m  PiAware setup is complete.\e[39m"
 echo ""
-read -p "Press enter to continue..." CONTINUE
+if [ ${VERBOSE} ] ; then
+    read -p "Press enter to continue..." CONTINUE
+fi
 
 exit 0

--- a/bash/feeders/planefinder.sh
+++ b/bash/feeders/planefinder.sh
@@ -62,7 +62,9 @@ if [ $CONTINUESETUP = 1 ]; then
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  Plane Finder ADS-B Client setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -144,7 +146,9 @@ if [ $(dpkg-query -W -f='${STATUS}' pfclient 2>/dev/null | grep -c "ok installed
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  Plane Finder ADS-B Client setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -162,6 +166,8 @@ echo ""
 echo -e "\e[93m-------------------------------------------------------------------------------------------------------"
 echo -e "\e[92m  Plane Finder ADS-B Client setup is complete.\e[39m"
 echo ""
-read -p "Press enter to continue..." CONTINUE
+if [ ${VERBOSE} ] ; then
+    read -p "Press enter to continue..." CONTINUE
+fi
 
 exit 0

--- a/bash/image.sh
+++ b/bash/image.sh
@@ -67,7 +67,9 @@ if (whiptail --backtitle "$ADSB_PROJECTTITLE" --title "ADS-B Receiver Project Im
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  Your operating system should now be up to date.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
 fi
 
 ## CONFIGURE DUMP1090
@@ -148,7 +150,9 @@ echo ""
 echo -e "\e[93m----------------------------------------------------------------------------------------------------"
 echo -e "\e[92m  Dump1090 configuration complete.\e[39m"
 echo ""
-read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
 
 
 # CONFIGURE PIAWARE IF NEEDED
@@ -212,7 +216,9 @@ if [ $(dpkg-query -W -f='${STATUS}' dump1090-fa 2>/dev/null | grep -c "ok instal
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  PiAware configuration complete.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
 fi
 
 ## SETUP THE ADS-B RECIEVER PROJECT WEB PORTAL

--- a/bash/portal/install.sh
+++ b/bash/portal/install.sh
@@ -61,7 +61,9 @@ if [ $CONTINUESETUP = 1 ]; then
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  ADS-B Receiver Project Portal setup halted.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
     exit 1
 fi
 
@@ -561,6 +563,8 @@ echo ""
 echo -e "\e[93m-------------------------------------------------------------------------------------------------------"
 echo -e "\e[92m  ADS-B Receiver Project Portal setup is complete.\e[39m"
 echo ""
-read -p "Press enter to continue..." CONTINUE
+if [ ${VERBOSE} ] ; then
+    read -p "Press enter to continue..." CONTINUE
+fi
 
 exit 0

--- a/bash/tools/portal_backup.sh
+++ b/bash/tools/portal_backup.sh
@@ -161,6 +161,8 @@ echo ""
 echo -e "\e[93m----------------------------------------------------------------------------------------------------"
 echo -e "\e[92m  Finished backing up portal data.\e[39m"
 echo ""
-read -p "Press enter to exit..." CONTINUE
+if [ ${VERBOSE} ] ; then
+    read -p "Press enter to continue..." CONTINUE
+fi
 
 exit 0

--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,7 @@ PROJECTBRANCH="master"
 PROJECTROOTDIRECTORY="$PWD"
 BASHDIRECTORY="$PROJECTROOTDIRECTORY/bash"
 BUILDDIRECTORY="$PROJECTROOTDIRECTORY/build"
+VERBOSE=""
 
 ## INCLUDE EXTERNAL SCRIPTS
 
@@ -49,6 +50,27 @@ source $BASHDIRECTORY/functions.sh
 
 export ADSB_PROJECTTITLE="The ADS-B Receiver Project Installer"
 TERMINATEDMESSAGE="  \e[91m  ANY FURTHER SETUP AND/OR INSTALLATION REQUESTS HAVE BEEN TERMINIATED\e[39m"
+
+## PARSE OPTIONS FROM CLI
+
+# Parse the command line options
+while [[ $1 = -* ]]; do
+        case "$1" in
+                -v|--verbose)
+                        VERBOSE="1"
+                        shift 1
+                        ;;
+                --help)
+                        usage
+                        exit 1
+                        ;;
+                *)
+                        echo "Error: Unknown option: $1" >&2
+                        usage
+                        exit 1
+                        ;;
+        esac
+done
 
 ## CHECK IF THIS IS THE FIRST RUN USING THE IMAGE RELEASE
 
@@ -80,7 +102,9 @@ function AptUpdate() {
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  Finished downloading and updating package lists.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then 
+       read -p "Press enter to continue..." CONTINUE
+    fi
 }
 
 function CheckPrerequisites() {
@@ -96,7 +120,9 @@ function CheckPrerequisites() {
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  The whiptail and git packages are installed.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
 }
 
 
@@ -119,7 +145,9 @@ function UpdateRepository() {
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  Finished pulling the latest version of the ADS-B Receiver Project repository....\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
 }
 
 # UPDATE THE OPERATING SYSTEM
@@ -135,7 +163,9 @@ function UpdateOperatingSystem() {
     echo -e "\e[93m----------------------------------------------------------------------------------------------------"
     echo -e "\e[92m  Your operating system should now be up to date.\e[39m"
     echo ""
-    read -p "Press enter to continue..." CONTINUE
+    if [ ${VERBOSE} ] ; then
+        read -p "Press enter to continue..." CONTINUE
+    fi
 }
 
 AptUpdate


### PR DESCRIPTION
My attempt at implementing the ability to run the install script without having to wait for the 'hit enter to continue' prompts as discussed in issue #251, feel free to disregard if equivalent functionality is imminent but if not then perhaps including this code could be an easy win in the short term?