### PR TITLE
update dump978.sh to fix dump978-maint.sh and feed dump1090-mutability

### DIFF
--- a/bash/decoders/dump978.sh
+++ b/bash/decoders/dump978.sh
@@ -218,11 +218,11 @@ sudo chmod +w $LIGHTTPDDOCUMENTROOTDIRECTORY/dump978/data
 # Create the dump978 maintenance script.
 echo -e "\e[94m  Creating the dump978 maintenance script...\e[97m"
 tee $DUMP978BUILDDIRECTORY/dump978-maint.sh > /dev/null <<EOF
-#! /bin/sh
+#! /bin/bash
 
 # Start dump978 without logging.
 while true; do
-    rtl_sdr -d $DUMP978DEVICE -f 978000000 -s 2083334 -g 48 - | $DUMP978BUILDDIRECTORY/dump978 | $DUMP978BUILDDIRECTORY/uat2json $LIGHTTPDDOCUMENTROOTDIRECTORY/dump978/data | $DUMP978BUILDDIRECTORY/uat2esnt | /bin/nc -q1 127.0.0.1 30001
+    rtl_sdr -d $DUMP978DEVICE -f 978000000 -s 2083334 -g 48 - | $DUMP978BUILDDIRECTORY/dump978 | tee >($DUMP978BUILDDIRECTORY/uat2json $LIGHTTPDDOCUMENTROOTDIRECTORY/dump978/data) | $DUMP978BUILDDIRECTORY/uat2esnt | /bin/nc -q1 127.0.0.1 30001
     sleep 15
 done
 EOF


### PR DESCRIPTION
dump978-maint.sh starts up dump978 and pipes output to uat2json (that updates dump978.php) and is then piped to uat2esnt and netcat (to dump1090-mutability).

However uat2json does not echo stdin to stdout output, meaning uat2esnt gets no input, and nothing makes it to dump1090-mutability.

This changes dump978-maint.sh to bash and uses tee to fork dump978's output to both uat2json and uat2esnt so messages make it to dump1090-mutability.