### PR TITLE
From Jessie to Stretch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The ADS-B Receiver Project website is located at https://www.adsbreceiver.net.
 
 ### Obtaining And Using This Software
 
-Download the latest ADS-B Receiver Raspbian Jessie Lite image for Raspberry Pi devices.
+Download the latest ADS-B Receiver Raspbian Stretch Lite image for Raspberry Pi devices.
 https://github.com/jprochazka/adsb-receiver/releases/latest
 
 When setting up the portal you will have to choose between a lite or advanced installation. Advanced features adds flight logging and plotting and should only be chosen on devices running a more sturdy data storage solution.


### PR DESCRIPTION
Update installation with download of Raspbian Stretch Lite instead of Jessie.