### PR TITLE
Update to maintenance.py to fix errors and the script bailing

### DIFF
--- a/build/portal/python/maintenance.py
+++ b/build/portal/python/maintenance.py
@@ -64,21 +64,21 @@ while True:
     cursor.execute("SELECT value FROM adsb_settings WHERE name = 'purgeFlights'")
     row = cursor.fetchone()
     if row:
-        purge_flights = int(row[0])
+        purge_flights = row
 
     purge_positions = False
     # MySQL and SQLite
     cursor.execute("SELECT value FROM adsb_settings WHERE name = 'purgePositions'")
     row = cursor.fetchone()
     if row:
-        purge_positions = int(row[0])
+        purge_positions = row
 
     purge_days_old = False
     # MySQL and SQLite
     cursor.execute("SELECT value FROM adsb_settings WHERE name = 'purgeDaysOld'")
-    row = cursor.fetchone()
+    row = cursor.fetchone()[0]
     if row:
-        purge_days_old = int(row[0])
+        purge_days_old = int(row)
 
     ## Create the purge date from the age specified.
 

--- a/build/portal/python/maintenance.py
+++ b/build/portal/python/maintenance.py
@@ -64,26 +64,26 @@ while True:
     cursor.execute("SELECT value FROM adsb_settings WHERE name = 'purgeFlights'")
     row = cursor.fetchone()
     if row:
-        purge_flights = row
+        purge_flights = int(row[0])
 
     purge_positions = False
     # MySQL and SQLite
     cursor.execute("SELECT value FROM adsb_settings WHERE name = 'purgePositions'")
     row = cursor.fetchone()
     if row:
-        purge_positions = row
+        purge_positions = int(row[0])
 
     purge_days_old = False
     # MySQL and SQLite
     cursor.execute("SELECT value FROM adsb_settings WHERE name = 'purgeDaysOld'")
     row = cursor.fetchone()
     if row:
-        purge_days_old = row
+        purge_days_old = int(row[0])
 
     ## Create the purge date from the age specified.
 
     if purge_days_old:
-        purge_datetime = datetime.datetime.utcnow() - timedelta(days=purge_days_old)
+        purge_datetime = datetime.datetime.utcnow() - datetime.timedelta(days=purge_days_old)
         purge_date = purge_datetime.strftime("%Y/%m/%d %H:%M:%S")
     else:
         purge_datetime = None


### PR DESCRIPTION
After my Sqlite3 db got huge, I checked the logs and found that the maint script was generating errors.

- changed 'purge_flights = row' to 'purge_flights = int(row[0])'
this explicitly gets the first result in the array and casts it to an int as the value returned from the DB (column type is TEXT') is unicode

- added missed datetime.

Have NOT tested on MySQL