### PR TITLE
v2.8.8 (Fixes to issues.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a history of the changes made to this project.
 
+## v2.8.8 *(August 23rd)*
+
+* FlightAware's version of the tcl-tls is now built and installed on Bullseye.
+
 ## v2.8.7 *(August 23rd)*
 
 * The ability to install dumpvdl2 is now available as a decoder option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The following is a history of the changes made to this project.
 ## v2.8.8 *(next release)*
 
 * FlightAware's version of the tcl-tls is now built and installed on Bullseye.
+* Clones athe trixie branch directly when using the forked version of piaware_builder.
 
-## v2.8.7 *(August 23rd)*
+## v2.8.7 *(August 23rd, 2024)*
 
 * The ability to install dumpvdl2 is now available as a decoder option.
 * The ability to install vdlm2dec is now available as a decoder option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 The following is a history of the changes made to this project.
 
-## v2.8.8 *(next release)*
+## v2.8.8 *(October 18th, 2024)*
 
 * FlightAware's version of the tcl-tls is now built and installed on Bullseye.
-* Clones athe trixie branch directly when using the forked version of piaware_builder.
+* Clones the trixie branch directly when using the forked version of piaware_builder.
+* The portal upgrade path to v2.8.7 was missing.
 
 ## v2.8.7 *(August 23rd, 2024)*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a history of the changes made to this project.
 
-## v2.8.8 *(August 23rd)*
+## v2.8.8 *(next release)*
 
 * FlightAware's version of the tcl-tls is now built and installed on Bullseye.
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -3,7 +3,8 @@
 ## Collaborators and Contributors
 
 First and foremost I would like to thank the collaborators and contributors who have contributed to
-the project directly. Their time and effort is greatly appreciated by myself as well as many others.
+the project directly through code contributions made directly to the repository. Their time and effort
+is greatly appreciated by myself as well as many others I am sure.
 
 * @adamkaplan
 * @atbPy

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ The project currently supports the following Linux distributions.
 * Debian _(Bookworm and Bullseye)_
 * DietPi _(Bookworm and Bullseye)_
 * Raspberry PI OS _(Bookworm and Bullseye)_
-* Ubuntu _(Jammy Jellyfish, Focal Fossa and Noble Numbat)_
+* Ubuntu _(Jammy Jellyfish, Focal Fossa and Noble Numbat*)_
 
 Support is available via this repository through the use of the issue tracker or discussions.
 
-_Please Note that Ubuntu Noble Numbat support employs an unofficial fix for PiAware._
+_* Please Note that Ubuntu Noble Numbat support employs an unofficial fix for PiAware._

--- a/bash/feeders/piaware.sh
+++ b/bash/feeders/piaware.sh
@@ -178,7 +178,7 @@ else
 
     # --- START TEMPORARY NOBLE FIX ---
     if [[ "${RECEIVER_OS_CODE_NAME}" == "noble" ]]; then
-        git clone https://github.com/jprochazka/piaware_builder.git 2>&1 | tee -a $RECEIVER_LOG_FILE
+        git clone -b trixie https://github.com/jprochazka/piaware_builder.git 2>&1 | tee -a $RECEIVER_LOG_FILE
     else
         git clone https://github.com/flightaware/piaware_builder.git 2>&1 | tee -a $RECEIVER_LOG_FILE
     fi
@@ -194,12 +194,6 @@ log_heading "Beginning the FlightAware PiAware installation process"
 
 log_message "Entering the piaware_builder git repository directory"
 cd $RECEIVER_BUILD_DIRECTORY/piaware_builder
-
-# --- START TEMPORARY NOBLE FIX ---
-if [[ "${RECEIVER_OS_CODE_NAME}" == "noble" ]]; then
-    git checkout trixie
-fi
-# --- END TEMPORARY NOBLE FIX ---
 
 log_message "Determining which piaware_builder build strategy should be use"
 distro="bookworm"

--- a/bash/feeders/piaware.sh
+++ b/bash/feeders/piaware.sh
@@ -3,7 +3,7 @@
 # THE FLIGHTAWARE PIAWARE CLIENT SETUP SCRIPT
 
 # JPROCHAZKA/PIAWARE_BUILDER REPOSITORY
-# -----------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------
 # I submitted a fix to support Debian Trixie and Ubuntu Noble Numbat to FlightAware's
 # piaware_builder repository. Until the changes are merged into their Git reposiory
 # the installation will be done using the fork I created along with the branch which
@@ -12,13 +12,11 @@
 # https://github.com/flightaware/piaware_builder/pull/26
 
 # TCLTLS-REBUILD
-# -----------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------
 # Along with PiAware, a version of tcltls maintained by FlightAware can be installed.
-# This package is only needed for Debian Buster and possibly Ubuntu Focal Fossa. Once 
-# these releases pass their end of life date the scripting will be removed.
+# This package is only needed for any distribution utilizing tcl-tls 1.7.22-2 or older.
 #
-# Debian Buster's end of life occured June 30, 2024 and is no longer supported.
-# Ubuntu Focal Fossa's end of life is scheduled for April 2025.
+# This fix may need to remain in place until Debian Bullseye hits end of life.
 
 
 ## PRE INSTALLATION OPERATIONS
@@ -90,7 +88,7 @@ fi
 
 ## CLONE OR PULL THE TCLTLS REBUILD GIT REPOSITORY
 
-if [[ "${RECEIVER_OS_CODE_NAME}" == "focal" ]]; then
+if [[ "${RECEIVER_OS_CODE_NAME}" == "focal" || "${RECEIVER_OS_CODE_NAME}" == "bullseye" ]]; then
 
     log_heading "Preparing the FlightAware tcltls-rebuild Git repository"
 

--- a/build/portal/html/classes/template.class.php
+++ b/build/portal/html/classes/template.class.php
@@ -8,7 +8,7 @@
 
             // Check if the portal is installed or needs upgraded.
 
-            $thisVersion = "2.8.7";
+            $thisVersion = "2.8.8";
 
             if (!file_exists($_SERVER['DOCUMENT_ROOT']."/classes/settings.class.php")) {
                 header ("Location: /install/install.php");

--- a/build/portal/html/install/index.php
+++ b/build/portal/html/install/index.php
@@ -1,6 +1,6 @@
 <?php
     // The most current stable release.
-    $thisVersion = "2.8.7";
+    $thisVersion = "2.8.8";
 
     // Begin the upgrade process if this release is newer than what is installed.
     if (file_exists($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR."classes".DIRECTORY_SEPARATOR."settings.class.php")) {

--- a/build/portal/html/install/upgrade-v2.8.8.php
+++ b/build/portal/html/install/upgrade-v2.8.8.php
@@ -1,0 +1,38 @@
+<?php
+    ///////////////////////
+    // UPGRADE TO V2.8.8
+    ///////////////////////
+
+    // --------------------------------------------------------
+    // Updates the version to 2.8.8
+    // --------------------------------------------------------
+
+    $results = upgrade();
+    exit(json_encode($results));
+
+    function upgrade() {
+        require_once($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR."classes".DIRECTORY_SEPARATOR."common.class.php");
+        require_once($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR."classes".DIRECTORY_SEPARATOR."settings.class.php");
+
+        $common = new common();
+        $settings = new settings();
+
+        try {
+            // Update the version and patch settings
+            $common->updateSetting("version", "2.8.8");
+            $common->updateSetting("patch", "");
+
+            // The upgrade process completed successfully
+            $results['success'] = TRUE;
+            $results['message'] = "Upgrade to v2.8.8 successful.";
+            return $results;
+
+        } catch(Exception $e) {
+            // Something went wrong during this upgrade process
+            $results['success'] = FALSE;
+            $results['message'] = $e->getMessage();
+            return $results;
+        }
+    }
+?>
+

--- a/build/portal/html/install/upgrade.php
+++ b/build/portal/html/install/upgrade.php
@@ -4,7 +4,7 @@
     $common = new common();
 
     // The most current stable release.
-    $thisVersion = "2.8.7";
+    $thisVersion = "2.8.8";
 
     // Begin the upgrade process if this release is newer than what is installed.
     if ($common->getSetting("version") == $thisVersion) {
@@ -209,6 +209,24 @@
         $success = $results['success'];
         $message = $results['message'];
         $version = "2.8.6";
+    }
+
+    // UPGRADE TO V2.8.7
+    if ($common->getSetting("version") == "2.8.6" && $success) {
+        $json = file_get_contents("http://localhost/install/upgrade-v2.8.7.php");
+        $results = json_decode($json, TRUE);
+        $success = $results['success'];
+        $message = $results['message'];
+        $version = "2.8.7";
+    }
+
+    // UPGRADE TO V2.8.8
+    if ($common->getSetting("version") == "2.8.7" && $success) {
+        $json = file_get_contents("http://localhost/install/upgrade-v2.8.8.php");
+        $results = json_decode($json, TRUE);
+        $success = $results['success'];
+        $message = $results['message'];
+        $version = "2.8.8";
     }
 
     require_once($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR."admin".DIRECTORY_SEPARATOR."includes".DIRECTORY_SEPARATOR."header.inc.php");

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 ## ASSIGN VARIABLE
 
-project_version="2.8.7"
+project_version="2.8.8"
 
 printf -v date_time '%(%Y-%m-%d_%H-%M-%S)T' -1
 log_file="adsb-installer_${date_time}.log"


### PR DESCRIPTION
This release contains a couple fixes as outlined below.

* FlightAware's version of the tcl-tls is now built and installed on Bullseye.
* Clones the trixie branch directly when using the forked version of piaware_builder.
* The portal upgrade path to v2.8.7 was missing.