### PR TITLE
v2.8.9 (AirNav Radar support added.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The following is a history of the changes made to this project.
 
+## v2.8.9 *(coming soon)*
+
+* Added the option to install the AirNav Radar rbfeeder client.
+* Removed scripting for FlightAware's version of the tcl-tls package.
+* Updated current feeder client versions in the variables file.
+* Removed support for Ubuntu 20.04 Focal Fossa.
+
 ## v2.8.8 *(October 18th, 2024)*
 
 * FlightAware's version of the tcl-tls is now built and installed on Bullseye.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a history of the changes made to this project.
 
-## v2.8.9 *(coming soon)*
+## v2.8.9 *(November 11th, 2025)*
 
 * Added the option to install the AirNav Radar rbfeeder client.
 * Removed scripting for FlightAware's version of the tcl-tls package.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -68,6 +68,7 @@ hard work and dedication to their respective projects this project would not hav
 Thanks also goes out to the developers and the businesses that employ them who work to supply us
 with quality closed source packages which they have made available to the community.
 
+* AirNav Radar      https://airnavradar.com
 * Flightradar24:    https://flightradar24.com
 * OpenSky Network:  https://opensky-network.org
 * Plane Finder:     https://planefinder.net

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ When setting up the portal you will have to choose between a lite or advanced in
 ### Feeders
 
 * ADS-B Exchange Feeder Client:   https://adsbexchange.com
+* AirNav Radar Client:            https://airnavradar.com
 * Airplanes.live Feeder Client:   https://airplanes.live
 * FlightAware's PiAware:          https://flightaware.com
 * Flightradar24 Feeder Client:    https://flightradar24.com
@@ -77,11 +78,11 @@ When setting up the portal you will have to choose between a lite or advanced in
 
 The project currently supports the following Linux distributions.
 
-* Armbian _(Bookworm, Jammy and Noble)_
+* Armbian _(Bookworm and Noble)_
 * Debian _(Bookworm and Bullseye)_
 * DietPi _(Bookworm and Bullseye)_
 * Raspberry PI OS _(Bookworm and Bullseye)_
-* Ubuntu _(Jammy Jellyfish, Focal Fossa and Noble Numbat*)_
+* Ubuntu _(Jammy Jellyfish and Noble Numbat*)_
 
 Support is available via this repository through the use of the issue tracker or discussions.
 

--- a/bash/decoders/dump1090-fa.sh
+++ b/bash/decoders/dump1090-fa.sh
@@ -94,9 +94,6 @@ cd $RECEIVER_BUILD_DIRECTORY/dump1090-fa/dump1090
 
 log_message "Determining which distribution to build the package tree for"
 case $RECEIVER_OS_CODE_NAME in
-    focal)
-        distro="buster"
-        ;;
     bullseye|jammy|bookworm|noble)
         distro="bullseye"
         ;;

--- a/bash/feeders/airnavradar.sh
+++ b/bash/feeders/airnavradar.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# MUST USE "OFFICIAL" AIRNAV RADAR RBFEEDER BINARIES
+# -------------------------------------------------------------------------------------
+# According to the AirNav Radar rbfeeder GitHub Issue Tracker any binaries built using
+# their source code repository not built by AirNav Radar themselves will not be able to
+# connect to their services.
+
+
+## PRE INSTALLATION OPERATIONS
+
+source $RECEIVER_BASH_DIRECTORY/variables.sh
+source $RECEIVER_BASH_DIRECTORY/functions.sh
+
+clear
+log_project_title
+log_title_heading "Setting up the AirNav Radar client"
+log_title_message "------------------------------------------------------------------------------"
+if ! whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
+              --title "AirNav Radar feeder client Setup" \
+              --yesno "The AirNav Radar feeder client takes data from a local dump1090 and dump978 instances and shares this with AirNav Radar using the rbfeeder package. More information on sharing data with AirNave Radar can be found here:\n\n  https://www.airnavradar.com/sharing-data\n\nContinue setup by installing the rbfeeder client?" \
+              13 78; then
+    echo ""
+    log_alert_heading "INSTALLATION HALTED"
+    log_alert_message "Setup has been halted at the request of the user"
+    echo ""
+    log_title_message "------------------------------------------------------------------------------"
+    log_title_heading "AirNav Radar client setup halted"
+    echo ""
+    exit 1
+fi
+
+
+## CHECK FOR PREREQUISITE PACKAGES
+
+log_heading "Installing packages needed to fulfill AirNav Radar rbfeeder dependencies"
+
+check_package dirmngr
+
+
+## ADD THE APT REPOSITORY
+
+log_heading "Adding the rb24 apt repository"
+
+log_message "Importing the key"
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 1D043681
+
+log_message "Removing the old source list"
+/bin/rm -f /etc/apt/sources.list.d/rb24.list
+
+log_message "Setting repository based on distribution"
+distro="bookworm"
+case $RECEIVER_OS_CODE_NAME in
+    focal)
+        echo 'deb https://apt.rb24.com/ buster main' > /etc/apt/sources.list.d/rb24.list
+        ;;
+    bullseye | jammy)
+        echo 'deb https://apt.rb24.com/ bullseye main' > /etc/apt/sources.list.d/rb24.list
+        ;;
+    bookworm | Focal)
+        echo 'deb https://apt.rb24.com/ bookworm main' > /etc/apt/sources.list.d/rb24.list
+        ;;
+    noble)
+        distro="trixie"
+        ;;
+esac
+log_message "Setting repository distribution to ${distro}"
+
+
+## UPDATE APT REPOSITORY AND INSTALL RBFEEDER
+
+log_heading "Updating apt repositories"
+apt update -y
+
+log_heading "Installing rbfeeder"
+check_package install rbfeeder -y
+
+
+## POST INSTALLATION OPERATIONS
+
+log_heading "Performing post installation operations"
+
+log_message "Asking for pre-existing sharing-key"
+sharing_key=$(whiptail --backtitle "AirNav Radar Feeder Client Setup" \
+                            --title "Enter Pre-Existing Sharing-Key" \
+                            --inputbox "\nEnter your sharing-key or leave blank if you do not have one." \
+                            8 78 \
+                            "" 3>&1 1>&2 2>&3)
+exit_status=$?
+if [[ $exit_status != 0 ]]; then
+    log_alert_heading "INSTALLATION HALTED"
+    log_alert_message "Setup has been halted due to user intervention"
+    echo ""
+    log_title_message "------------------------------------------------------------------------------"
+    log_title_heading "AirNav Radar Feeder Client setup halted"
+    exit 1
+fi
+
+if [[ -n "${sharing_key}" ]] ; then
+    log_message "Attempting to set sharing-key to ${sharing_key}"
+    sudo rbfeeder --setkey $sharing_key
+fi
+
+wait_time=5
+log_message "Waiting ${wait_time} seconds before continuing "
+echo -n "Waiting for $wait_time seconds: "
+for ((i=0; i<wait_time; i++)); do
+  echo -n "."
+  sleep 1
+done
+
+log_message "Attempting to retreive sharing-key from AirNav Radar"
+real_sharing_key=`sudo rbfeeder --showkey`
+log_message "Sharing-key set to ${real_sharing_key}"
+
+
+## SETUP COMPLETE
+
+log_message "Returning to ${RECEIVER_PROJECT_TITLE} root directory"
+cd $RECEIVER_ROOT_DIRECTORY
+
+echo ""
+log_title_message "------------------------------------------------------------------------------"
+log_title_heading "AirNav Radar client setup is complete"
+echo ""
+read -p "Press enter to continue..." discard
+
+exit 0

--- a/bash/feeders/airnavradar.sh
+++ b/bash/feeders/airnavradar.sh
@@ -51,13 +51,10 @@ log_message "Removing the old source list"
 log_message "Setting repository based on distribution"
 distro="bookworm"
 case $RECEIVER_OS_CODE_NAME in
-    focal)
-        echo 'deb https://apt.rb24.com/ buster main' > /etc/apt/sources.list.d/rb24.list
-        ;;
     bullseye | jammy)
         echo 'deb https://apt.rb24.com/ bullseye main' > /etc/apt/sources.list.d/rb24.list
         ;;
-    bookworm | Focal)
+    bookworm)
         echo 'deb https://apt.rb24.com/ bookworm main' > /etc/apt/sources.list.d/rb24.list
         ;;
     noble)

--- a/bash/feeders/airnavradar.sh
+++ b/bash/feeders/airnavradar.sh
@@ -73,7 +73,7 @@ log_heading "Updating apt repositories"
 apt update -y
 
 log_heading "Installing rbfeeder"
-check_package install rbfeeder -y
+check_package rbfeeder
 
 
 ## POST INSTALLATION OPERATIONS

--- a/bash/main.sh
+++ b/bash/main.sh
@@ -250,9 +250,26 @@ else
     echo "ADS-B Exchange Feed Client" >> ${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES
     feeder_list=("${feeder_list[@]}" 'ADS-B Exchange Feed Client' '' OFF)
 fi
+
 function install_adsbexchange_client() {
     chmod +x ${RECEIVER_BASH_DIRECTORY}/feeders/adsbexchange.sh
     ${RECEIVER_BASH_DIRECTORY}/feeders/adsbexchange.sh
+    if [[ $? != 0 ]] ; then
+        exit 1
+    fi
+}
+
+# AirNav Radar rbfeeder
+if [[ $(dpkg-query -W -f='${STATUS}' rbfeeder 2>/dev/null | grep -c "ok installed") == 0 ]]; then
+    feeder_list=("${feeder_list[@]}" 'AirNav Radar RBFeeder' '' OFF)
+else
+    echo "AirNav Radar RBFeeder (reinstall)" >> ${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES
+    feeder_list=("${feeder_list[@]}" 'AirNav Radar RBFeeder (reinstall/update)' '' OFF)
+fi
+
+function install_airnavradar_client() {
+    chmod +x ${RECEIVER_BASH_DIRECTORY}/feeders/airnavradar.sh
+    ${RECEIVER_BASH_DIRECTORY}/feeders/airnavradar.sh
     if [[ $? != 0 ]] ; then
         exit 1
     fi
@@ -634,6 +651,7 @@ fi
 
 # Aggragate site clients
 run_adsbexchange_script="false"
+run_airnavradar_script="false"
 run_airplaneslive_script="false"
 run_flightaware_script="false"
 run_flightradar24_script="false"
@@ -647,6 +665,9 @@ if [[ -s "${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES" ]]; then
         case ${feeder_choice} in
             "ADS-B Exchange Feed Client"|"ADS-B Exchange Feed Client (reinstall/update)")
                 run_adsbexchange_script="true"
+                ;;
+            "AirNav Radar RBFeeder"|"AirNav Radar RBFeeder (reinstall/update)")
+                run_airnavradar_script="true"
                 ;;
             "Airplanes.live Feeder"|"Airplanes.live Feeder (reinstall)")
                 run_airplaneslive_script="true"
@@ -672,6 +693,10 @@ fi
 
 if [[ "${run_adsbexchange_script}" == "true" ]]; then
     install_adsbexchange_client
+fi
+
+if [[ "${run_airnavradar_script}" == "true" ]]; then
+    install_airnavradar_client
 fi
 
 if [[ "${run_airplaneslive_script}" == "true" ]]; then

--- a/bash/variables.sh
+++ b/bash/variables.sh
@@ -18,18 +18,18 @@ display_true_inline="\033[2;32m"
 ## SOFTWARE VERSIONS
 
 # FlightAware
-dump1090_fa_current_version="9.0"
-dump978_fa_current_version="9.0"
-piaware_current_version="9.0.1"
+dump1090_fa_current_version="10.2"
+dump978_fa_current_version="10.2"
+piaware_current_version="10.2"
 
 # PlaneFinder Client
-pfclient_current_version_armhf="5.0.161"
-pfclient_current_version_arm64="5.1.440"
+pfclient_current_version_armhf="5.3.2"
+pfclient_current_version_arm64="5.3.2"
 pfclient_current_version_amd64="5.0.162"
 pfclient_current_version_i386="5.0.161"
 
 # Flightradar24 Client
-fr24feed_current_version="1.0.48-0"
+fr24feed_current_version="1.0.51-0"
 
 # OpenSky Network Client
 opensky_feeder_current_version="2.1.7-1"

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 ## ASSIGN VARIABLE
 
-project_version="2.8.8"
+project_version="2.8.9"
 
 printf -v date_time '%(%Y-%m-%d_%H-%M-%S)T' -1
 log_file="adsb-installer_${date_time}.log"


### PR DESCRIPTION
### v2.8.9

- Added the option to install the AirNav Radar rbfeeder client.
- Removed scripting for FlightAware's version of the tcl-tls package.
- Updated current feeder client versions in the variables file.
- Removed support for Ubuntu 20.04 Focal Fossa.