### PR TITLE
v2.8.10 (Refactoring and updates.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The following is a history of the changes made to this project.
 
+## v2.8.10 *(Coming soon...)*
+
+* Refactored core bash scripts.
+* The no logging parameter option is now respected.
+* Correct install script is used when BeastSpliter is selected.
+* Correct CPU architecture is used to pick Plane Finder client.
+* Update Flightradar24 client version.
+* Updated Plane Finder ADS-B client versions.
+* Removed i386 Plane Finder ADS-B client option.
+
 ## v2.8.9 *(November 11th, 2025)*
 
 * Added the option to install the AirNav Radar rbfeeder client.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The following is a history of the changes made to this project.
 
 ## v2.8.10 *(Coming soon...)*
 
+* Check for the rsyslog package before installing PiAware.
 * Refactored core bash scripts.
 * The no logging parameter option is now respected.
 * Correct install script is used when BeastSpliter is selected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 The following is a history of the changes made to this project.
 
-## v2.8.10 *(Coming soon...)*
+## v2.8.10 *(April 9th, 2026)*
 
+* Trixie, Noble and Questing uses the official piaware_builder dev branch.
+* Correct Ubuntu versions are associated with matching Debian version.
+* Specify correct versions of PHP for Noble and Questing.
 * Check for the rsyslog package before installing PiAware.
 * Refactored core bash scripts.
 * The no logging parameter option is now respected.

--- a/README.md
+++ b/README.md
@@ -78,12 +78,10 @@ When setting up the portal you will have to choose between a lite or advanced in
 
 The project currently supports the following Linux distributions.
 
-* Raspberry PI OS _(Legacy, Current*)_
-* Debian _(Bullseye, Bookworm, Trixie*)_
-* Ubuntu _(Jammy, Noble Numbat*, Questing Quokka*)_
+* Raspberry PI OS _(Legacy, Current)_
+* Debian _(Bookworm, Trixie)_
+* Ubuntu _(Jammy Jellyfish, Noble Numbat, Questing Quokka)_
 
 _These scripts should work most any Debian based distributions_
 
 Support is available via this repository through the use of the issue tracker or discussions.
-
-_* Requires an unofficial fix to install PiAware._

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ When setting up the portal you will have to choose between a lite or advanced in
 
 The project currently supports the following Linux distributions.
 
-* Armbian _(Bookworm and Noble)_
-* Debian _(Bookworm and Bullseye)_
-* DietPi _(Bookworm and Bullseye)_
-* Raspberry PI OS _(Bookworm and Bullseye)_
-* Ubuntu _(Jammy Jellyfish and Noble Numbat*)_
+* Raspberry PI OS _(Legacy, Current*)_
+* Debian _(Bullseye, Bookworm, Trixie*)_
+* Ubuntu _(Jammy, Noble Numbat*, Questing Quokka*)_
+
+_These scripts should work most any Debian based distributions_
 
 Support is available via this repository through the use of the issue tracker or discussions.
 
-_* Please Note that Ubuntu Noble Numbat support employs an unofficial fix for PiAware._
+_* Requires an unofficial fix to install PiAware._

--- a/bash/decoders/acarsdec.sh
+++ b/bash/decoders/acarsdec.sh
@@ -108,7 +108,6 @@ case $RECEIVER_OS_DISTRIBUTION in
         distro_php_version=""
         ;;
     debian)
-        if [[ "${RECEIVER_OS_CODE_NAME}" == "bullseye" ]]; then distro_php_version="7.4"; fi
         if [[ "${RECEIVER_OS_CODE_NAME}" == "bookworm" ]]; then distro_php_version="8.2"; fi
         if [[ "${RECEIVER_OS_CODE_NAME}" == "trixie" ]]; then distro_php_version="8.4"; fi
         ;;

--- a/bash/decoders/acarsdec.sh
+++ b/bash/decoders/acarsdec.sh
@@ -108,8 +108,9 @@ case $RECEIVER_OS_DISTRIBUTION in
         distro_php_version=""
         ;;
     debian)
-        if [[ "${RECEIVER_OS_CODE_NAME}" == "bookworm" ]]; then distro_php_version="8.2"; fi
         if [[ "${RECEIVER_OS_CODE_NAME}" == "bullseye" ]]; then distro_php_version="7.4"; fi
+        if [[ "${RECEIVER_OS_CODE_NAME}" == "bookworm" ]]; then distro_php_version="8.2"; fi
+        if [[ "${RECEIVER_OS_CODE_NAME}" == "trixie" ]]; then distro_php_version="8.4"; fi
         ;;
 esac
 check_package sqlite3

--- a/bash/decoders/dump1090-fa.sh
+++ b/bash/decoders/dump1090-fa.sh
@@ -94,7 +94,7 @@ cd $RECEIVER_BUILD_DIRECTORY/dump1090-fa/dump1090
 
 log_message "Determining which distribution to build the package tree for"
 case $RECEIVER_OS_CODE_NAME in
-    bullseye|jammy|bookworm|noble)
+    bullseye|jammy|bookworm|noble|questing)
         distro="bullseye"
         ;;
 esac

--- a/bash/decoders/dump1090-fa.sh
+++ b/bash/decoders/dump1090-fa.sh
@@ -71,17 +71,17 @@ if [[ -d $RECEIVER_BUILD_DIRECTORY/dump1090-fa/dump1090 && -d $RECEIVER_BUILD_DI
     cd $RECEIVER_BUILD_DIRECTORY/dump1090-fa/dump1090
     log_message "Pulling the dump1090 git repository"
     echo ""
-    git pull 2>&1 | tee -a $RECEIVER_LOG_FILE
+    git pull 2>&1 | log_pipe
 else
     log_message "Creating the FlightAware dump1090 Project build directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/dump1090-fa 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/dump1090-fa 2>&1 | log_pipe
     echo ""
     log_message "Entering the FlightAware dump1090 Project build directory"
     cd $RECEIVER_BUILD_DIRECTORY/dump1090-fa
     log_message "Cloning the dump1090 git repository"
     echo ""
-    git clone https://github.com/flightaware/dump1090.git 2>&1 | tee -a $RECEIVER_LOG_FILE
+    git clone https://github.com/flightaware/dump1090.git 2>&1 | log_pipe
 fi
 
 
@@ -100,17 +100,17 @@ case $RECEIVER_OS_CODE_NAME in
 esac
 log_message "Preparing to build dump1090-fa for ${distro}"
 echo ""
-./prepare-build.sh $distro 2>&1 | tee -a $RECEIVER_LOG_FILE
+./prepare-build.sh $distro 2>&1 | log_pipe
 echo ""
 log_message "Entering the package-${distro} directory"
 cd $RECEIVER_BUILD_DIRECTORY/dump1090-fa/dump1090/package-$distro
 log_message "Building the dump1090-fa Debian package"
 echo ""
-dpkg-buildpackage -b --no-sign 2>&1 | tee -a $RECEIVER_LOG_FILE
+dpkg-buildpackage -b --no-sign 2>&1 | log_pipe
 echo ""
 log_message "Installing the dump1090-fa Debian package"
 echo ""
-sudo dpkg -i $RECEIVER_BUILD_DIRECTORY/dump1090-fa/dump1090/dump1090-fa_$DUMP1090_FA_VERSION_*.deb 2>&1 | tee -a $RECEIVER_LOG_FILE
+sudo dpkg -i $RECEIVER_BUILD_DIRECTORY/dump1090-fa/dump1090/dump1090-fa_$DUMP1090_FA_VERSION_*.deb 2>&1 | log_pipe
 echo ""
 
 log_message "Checking that the dump1090-fa Debian package was installed"
@@ -131,12 +131,12 @@ fi
 if [[ ! -d $RECEIVER_BUILD_DIRECTORY/package-archive ]]; then
     log_message "Creating the Debian package archive directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/package-archive 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/package-archive 2>&1 | log_pipe
     echo ""
 fi
 log_message "Copying the dump1090-fa Debian package into the Debian package archive directory"
 echo ""
-cp -vf $RECEIVER_BUILD_DIRECTORY/dump1090-fa/dump1090/*.deb $RECEIVER_BUILD_DIRECTORY/package-archive/ 2>&1 | tee -a $RECEIVER_LOG_FILE
+cp -vf $RECEIVER_BUILD_DIRECTORY/dump1090-fa/dump1090/*.deb $RECEIVER_BUILD_DIRECTORY/package-archive/ 2>&1 | log_pipe
 
 
 ## CONFIGURATION
@@ -195,7 +195,7 @@ if [[ ! -f "/usr/share/dump1090-fa/html/upintheair.json" ]]; then
 
             log_message "Downloading JSON data file assigned to panorama ID ${heywhatsthat_panorama_id}"
             echo ""
-            sudo wget -v -O /usr/share/skyaware/html/upintheair.json "http://www.heywhatsthat.com/api/upintheair.json?id=${heywhatsthat_panarama_id}&refraction=0.25&alts=${heywhatsthat_ring_one_altitude},${heywhatsthat_ring_two_altitude}" 2>&1 | tee -a $RECEIVER_LOG_FILE
+            sudo wget -v -O /usr/share/skyaware/html/upintheair.json "http://www.heywhatsthat.com/api/upintheair.json?id=${heywhatsthat_panarama_id}&refraction=0.25&alts=${heywhatsthat_ring_one_altitude},${heywhatsthat_ring_two_altitude}" 2>&1 | log_pipe
             echo ""
             log_message "Heywhatsthat configuration complete"
         fi

--- a/bash/decoders/dump1090-fa.sh
+++ b/bash/decoders/dump1090-fa.sh
@@ -93,10 +93,8 @@ log_message "Entering the dump1090 Git repository"
 cd $RECEIVER_BUILD_DIRECTORY/dump1090-fa/dump1090
 
 log_message "Determining which distribution to build the package tree for"
-case $RECEIVER_OS_CODE_NAME in
-    bullseye|jammy|bookworm|noble|questing)
-        distro="bullseye"
-        ;;
+distro="bullseye"
+
 esac
 log_message "Preparing to build dump1090-fa for ${distro}"
 echo ""

--- a/bash/decoders/dump978-fa.sh
+++ b/bash/decoders/dump978-fa.sh
@@ -68,17 +68,17 @@ if [[ -d $RECEIVER_BUILD_DIRECTORY/dump978-fa/dump978 && -d $RECEIVER_BUILD_DIRE
     cd $RECEIVER_BUILD_DIRECTORY/dump978-fa/dump978
     log_message "Pulling the dump1090 git repository"
     echo ""
-    git pull 2>&1 | tee -a $RECEIVER_LOG_FILE
+    git pull 2>&1 | log_pipe
 else
     log_message "Creating the FlightAware dump978 Project build directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/dump978-fa 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/dump978-fa 2>&1 | log_pipe
     echo ""
     log_message "Entering the ADS-B Receiver Project build directory"
     cd $RECEIVER_BUILD_DIRECTORY/dump978-fa
     log_message "Cloning the FlightAware dump978 git repository"
     echo ""
-    git clone https://github.com/flightaware/dump978.git 2>&1 | tee -a $RECEIVER_LOG_FILE
+    git clone https://github.com/flightaware/dump978.git 2>&1 | log_pipe
 fi
 
 
@@ -91,16 +91,16 @@ cd $RECEIVER_BUILD_DIRECTORY/dump978-fa/dump978
 
 log_message "Building the dump978-fa package"
 echo ""
-dpkg-buildpackage -b 2>&1 | tee -a $RECEIVER_LOG_FILE
+dpkg-buildpackage -b 2>&1 | log_pipe
 echo ""
 
 log_message "Installing the dump978-fa Debian package"
 echo ""
-sudo dpkg -i $RECEIVER_BUILD_DIRECTORY/dump978-fa/dump978-fa_*.deb 2>&1 | tee -a $RECEIVER_LOG_FILE
+sudo dpkg -i $RECEIVER_BUILD_DIRECTORY/dump978-fa/dump978-fa_*.deb 2>&1 | log_pipe
 echo ""
 log_message "Installing the skyaware978 Debian package"
 echo ""
-sudo dpkg -i $RECEIVER_BUILD_DIRECTORY/dump978-fa/skyaware978_*.deb 2>&1 | tee -a $RECEIVER_LOG_FILE
+sudo dpkg -i $RECEIVER_BUILD_DIRECTORY/dump978-fa/skyaware978_*.deb 2>&1 | log_pipe
 echo ""
 
 log_message "Checking that the dump978-fa Debian package was installed"
@@ -136,16 +136,16 @@ fi
 if [[ ! -d $RECEIVER_BUILD_DIRECTORY/package-archive ]]; then
     log_message "Creating the Debian package archive directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/package-archive 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/package-archive 2>&1 | log_pipe
     echo ""
 fi
 log_message "Copying the dump978-fa Debian package into the Debian package archive directory"
 echo ""
-cp -vf $RECEIVER_BUILD_DIRECTORY/dump978-fa/dump978-fa_*.deb $RECEIVER_BUILD_DIRECTORY/package-archive/ 2>&1 | tee -a $RECEIVER_LOG_FILE
+cp -vf $RECEIVER_BUILD_DIRECTORY/dump978-fa/dump978-fa_*.deb $RECEIVER_BUILD_DIRECTORY/package-archive/ 2>&1 | log_pipe
 echo ""
 log_message "Copying the skyaware978 Debian package into the Debian package archive directory"
 echo ""
-cp -vf $RECEIVER_BUILD_DIRECTORY/dump978-fa/skyaware978_*.deb $RECEIVER_BUILD_DIRECTORY/package-archive/ 2>&1 | tee -a $RECEIVER_LOG_FILE
+cp -vf $RECEIVER_BUILD_DIRECTORY/dump978-fa/skyaware978_*.deb $RECEIVER_BUILD_DIRECTORY/package-archive/ 2>&1 | log_pipe
 
 
 ## CONFIGURATION

--- a/bash/decoders/dumpvdl2.sh
+++ b/bash/decoders/dumpvdl2.sh
@@ -85,7 +85,6 @@ case $RECEIVER_OS_DISTRIBUTION in
         distro_php_version=""
         ;;
     debian)
-        if [[ "${RECEIVER_OS_CODE_NAME}" == "bullseye" ]]; then distro_php_version="7.4"; fi
         if [[ "${RECEIVER_OS_CODE_NAME}" == "bookworm" ]]; then distro_php_version="8.2"; fi
         if [[ "${RECEIVER_OS_CODE_NAME}" == "trixie" ]]; then distro_php_version="8.4"; fi
         ;;

--- a/bash/decoders/dumpvdl2.sh
+++ b/bash/decoders/dumpvdl2.sh
@@ -85,8 +85,9 @@ case $RECEIVER_OS_DISTRIBUTION in
         distro_php_version=""
         ;;
     debian)
-        if [[ "${RECEIVER_OS_CODE_NAME}" == "bookworm" ]]; then distro_php_version="8.2"; fi
         if [[ "${RECEIVER_OS_CODE_NAME}" == "bullseye" ]]; then distro_php_version="7.4"; fi
+        if [[ "${RECEIVER_OS_CODE_NAME}" == "bookworm" ]]; then distro_php_version="8.2"; fi
+        if [[ "${RECEIVER_OS_CODE_NAME}" == "trixie" ]]; then distro_php_version="8.4"; fi
         ;;
 esac
 check_package sqlite3

--- a/bash/decoders/readsb.sh
+++ b/bash/decoders/readsb.sh
@@ -71,17 +71,17 @@ if [[ -d $RECEIVER_BUILD_DIRECTORY/readsb/readsb && -d $RECEIVER_BUILD_DIRECTORY
     cd $RECEIVER_BUILD_DIRECTORY/readsb/readsb
     log_message "Pulling the Readsb git repository"
     echo ""
-    git pull 2>&1 | tee -a $RECEIVER_LOG_FILE
+    git pull 2>&1 | log_pipe
 else
     log_message "Creating the Readsb Project build directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/readsb 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/readsb 2>&1 | log_pipe
     echo ""
     log_message "Entering the Readsb Project build directory"
     cd $RECEIVER_BUILD_DIRECTORY/readsb
     log_message "Cloning the readsb git repository"
     echo ""
-    git clone https://github.com/wiedehopf/readsb.git 2>&1 | tee -a $RECEIVER_LOG_FILE
+    git clone https://github.com/wiedehopf/readsb.git 2>&1 | log_pipe
 fi
 
 
@@ -120,12 +120,12 @@ fi
 if [[ ! -d $RECEIVER_BUILD_DIRECTORY/package-archive ]]; then
     log_message "Creating the Debian package archive directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/package-archive 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/package-archive 2>&1 | log_pipe
     echo ""
 fi
 log_message "Copying the Readsb Debian package into the Debian package archive directory"
 echo ""
-cp -vf $RECEIVER_BUILD_DIRECTORY/readsb/*.deb $RECEIVER_BUILD_DIRECTORY/package-archive/ 2>&1 | tee -a $RECEIVER_LOG_FILE
+cp -vf $RECEIVER_BUILD_DIRECTORY/readsb/*.deb $RECEIVER_BUILD_DIRECTORY/package-archive/ 2>&1 | log_pipe
 
 
 ## CONFIGURATION

--- a/bash/decoders/vdlm2dec.sh
+++ b/bash/decoders/vdlm2dec.sh
@@ -99,7 +99,6 @@ case $RECEIVER_OS_DISTRIBUTION in
         distro_php_version=""
         ;;
     debian)
-        if [[ "${RECEIVER_OS_CODE_NAME}" == "bullseye" ]]; then distro_php_version="7.4"; fi
         if [[ "${RECEIVER_OS_CODE_NAME}" == "bookworm" ]]; then distro_php_version="8.2"; fi
         if [[ "${RECEIVER_OS_CODE_NAME}" == "trixie" ]]; then distro_php_version="8.4"; fi
         ;;

--- a/bash/decoders/vdlm2dec.sh
+++ b/bash/decoders/vdlm2dec.sh
@@ -99,8 +99,9 @@ case $RECEIVER_OS_DISTRIBUTION in
         distro_php_version=""
         ;;
     debian)
-        if [[ "${RECEIVER_OS_CODE_NAME}" == "bookworm" ]]; then distro_php_version="8.2"; fi
         if [[ "${RECEIVER_OS_CODE_NAME}" == "bullseye" ]]; then distro_php_version="7.4"; fi
+        if [[ "${RECEIVER_OS_CODE_NAME}" == "bookworm" ]]; then distro_php_version="8.2"; fi
+        if [[ "${RECEIVER_OS_CODE_NAME}" == "trixie" ]]; then distro_php_version="8.4"; fi
         ;;
 esac
 check_package sqlite3

--- a/bash/extras/beastsplitter.sh
+++ b/bash/extras/beastsplitter.sh
@@ -89,17 +89,17 @@ if [[ -d $RECEIVER_BUILD_DIRECTORY/beast-splitter/beast-splitter && -d $RECEIVER
     cd $RECEIVER_BUILD_DIRECTORY/beast-splitter/beast-splitter
     log_message "Pulling the beast-splitter git repository"
     echo ""
-    git pull 2>&1 | tee -a $RECEIVER_LOG_FILE
+    git pull 2>&1 | log_pipe
 else
     log_message "Creating the beast-splitter build directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/beast-splitter 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/beast-splitter 2>&1 | log_pipe
     echo ""
     log_message "Entering the beast-splitter build directory"
     cd $RECEIVER_BUILD_DIRECTORY/beast-splitter
     log_message "Cloning the beast-splitter git repository"
     echo ""
-    git clone https://github.com/flightaware/beast-splitter.git 2>&1 | tee -a $RECEIVER_LOG_FILE
+    git clone https://github.com/flightaware/beast-splitter.git 2>&1 | log_pipe
 fi
 
 
@@ -112,12 +112,12 @@ cd $RECEIVER_BUILD_DIRECTORY/beast-splitter/beast-splitter
 
 log_message "Building the beast-splitter package"
 echo ""
-dpkg-buildpackage -b 2>&1 | tee -a $RECEIVER_LOG_FILE
+dpkg-buildpackage -b 2>&1 | log_pipe
 echo ""
 
 log_message "Installing the beast-splitter Debian package"
 echo ""
-sudo dpkg -i $RECEIVER_BUILD_DIRECTORY/beast-splitter/beast-splitter_*.deb 2>&1 | tee -a $RECEIVER_LOG_FILE
+sudo dpkg -i $RECEIVER_BUILD_DIRECTORY/beast-splitter/beast-splitter_*.deb 2>&1 | log_pipe
 echo ""
 
 log_message "Checking that the beast-splitter Debian package was installed"
@@ -138,12 +138,12 @@ fi
 if [[ ! -d $RECEIVER_BUILD_DIRECTORY/package-archive ]]; then
     log_message "Creating the Debian package archive directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/package-archive 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/package-archive 2>&1 | log_pipe
     echo ""
 fi
 log_message "Copying the beast-splitter Debian package into the Debian package archive directory"
 echo ""
-cp -vf $RECEIVER_BUILD_DIRECTORY/beast-splitter/*.deb $RECEIVER_BUILD_DIRECTORY/package-archive/ 2>&1 | tee -a $RECEIVER_LOG_FILE
+cp -vf $RECEIVER_BUILD_DIRECTORY/beast-splitter/*.deb $RECEIVER_BUILD_DIRECTORY/package-archive/ 2>&1 | log_pipe
 
 
 ## CONFIGURATION

--- a/bash/extras/duckdns.sh
+++ b/bash/extras/duckdns.sh
@@ -80,7 +80,7 @@ log_heading "Creating the Duck DNS script"
 if [[ ! -d $RECEIVER_BUILD_DIRECTORY/duckdns ]]; then
     log_message "Creating the Duck DNS build directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/duckdns 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/duckdns 2>&1 | log_pipe
     echo ""
 fi
 
@@ -91,7 +91,7 @@ EOF
 
 log_message "Adding execute permissions for only this user to the Duck DNS update script"
 echo ""
-chmod -v 700 $RECEIVER_BUILD_DIRECTORY/duckdns/duck.sh 2>&1 | tee -a $RECEIVER_LOG_FILE
+chmod -v 700 $RECEIVER_BUILD_DIRECTORY/duckdns/duck.sh 2>&1 | log_pipe
 echo ""
 
 log_message "Creating the Duck DNS cron file"

--- a/bash/extras/graphs1090.sh
+++ b/bash/extras/graphs1090.sh
@@ -36,7 +36,7 @@ log_message "Entering the Graphs1090 build directory"
 cd $RECEIVER_BUILD_DIRECTORY/graphs1090
 log_message "Downloading the Graphs1090 install script"
 echo ""
-wget -v -O $RECEIVER_BUILD_DIRECTORY/graphs1090/install.sh https://github.com/wiedehopf/graphs1090/raw/master/install.sh 2>&1 | tee -a $RECEIVER_LOG_FILE
+wget -v -O $RECEIVER_BUILD_DIRECTORY/graphs1090/install.sh https://github.com/wiedehopf/graphs1090/raw/master/install.sh 2>&1 | log_pipe
 log_message "Executing the Graphs1090 install script"
 echo ""
 sudo bash $RECEIVER_BUILD_DIRECTORY/graphs1090/install.sh

--- a/bash/extras/tar1090.sh
+++ b/bash/extras/tar1090.sh
@@ -42,7 +42,7 @@ log_message "Entering the tar1090 build directory"
 cd $RECEIVER_BUILD_DIRECTORY/tar1090
 log_message "Downloading the tar1090 install script"
 echo ""
-wget -v -O $RECEIVER_BUILD_DIRECTORY/tar1090/install.sh https://raw.githubusercontent.com/wiedehopf/tar1090/master/install.sh 2>&1 | tee -a $RECEIVER_LOG_FILE
+wget -v -O $RECEIVER_BUILD_DIRECTORY/tar1090/install.sh https://raw.githubusercontent.com/wiedehopf/tar1090/master/install.sh 2>&1 | log_pipe
 log_message "Executing the tar1090 install script"
 echo ""
 sudo bash $RECEIVER_BUILD_DIRECTORY/tar1090/install.sh

--- a/bash/feeders/adsbexchange.sh
+++ b/bash/feeders/adsbexchange.sh
@@ -37,7 +37,7 @@ whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
 if [[ ! -d $RECEIVER_BUILD_DIRECTORY/adsbexchange ]]; then
     log_message "Creating the ADSBExchange build directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/adsbexchange 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/adsbexchange 2>&1 | log_pipe
     echo ""
 fi
 log_message "Entering the ADSBExchange build directory"
@@ -52,9 +52,9 @@ fi
 log_message "Downloading the ADS-B Exchange client ${action_to_perform} script"
 echo ""
 if [[ "${action_to_perform}" = "install" ]]; then
-    wget -v -O $RECEIVER_BUILD_DIRECTORY/adsbexchange/feed-${action_to_perform}.sh https://www.adsbexchange.com/feed.sh 2>&1 | tee -a $RECEIVER_LOG_FILE
+    wget -v -O $RECEIVER_BUILD_DIRECTORY/adsbexchange/feed-${action_to_perform}.sh https://www.adsbexchange.com/feed.sh 2>&1 | log_pipe
 else
-    wget -v -O $RECEIVER_BUILD_DIRECTORY/adsbexchange/feed-${action_to_perform}.sh https://www.adsbexchange.com/feed-update.sh 2>&1 | tee -a $RECEIVER_LOG_FILE
+    wget -v -O $RECEIVER_BUILD_DIRECTORY/adsbexchange/feed-${action_to_perform}.sh https://www.adsbexchange.com/feed-update.sh 2>&1 | log_pipe
 fi
 echo ""
 
@@ -75,7 +75,7 @@ if whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
             12 78; then
     log_message "Downloading the ADS-B Exchange stats package installation script"
     echo ""
-    wget -v -O $RECEIVER_BUILD_DIRECTORY/adsbexchange/axstats.sh https://adsbexchange.com/stats.sh 2>&1 | tee -a $RECEIVER_LOG_FILE
+    wget -v -O $RECEIVER_BUILD_DIRECTORY/adsbexchange/axstats.sh https://adsbexchange.com/stats.sh 2>&1 | log_pipe
     echo ""
     echo -e "Executing the ADS-B Exchange stats package installation script"
     echo ""

--- a/bash/feeders/airnavradar.sh
+++ b/bash/feeders/airnavradar.sh
@@ -51,7 +51,7 @@ log_message "Removing the old source list"
 log_message "Setting repository based on distribution"
 distro="bookworm"
 case $RECEIVER_OS_CODE_NAME in
-    bullseye | jammy)
+    jammy)
         echo 'deb https://apt.rb24.com/ bullseye main' > /etc/apt/sources.list.d/rb24.list
         ;;
     bookworm)

--- a/bash/feeders/airnavradar.sh
+++ b/bash/feeders/airnavradar.sh
@@ -58,7 +58,7 @@ case $RECEIVER_OS_CODE_NAME in
         echo 'deb https://apt.rb24.com/ bookworm main' > /etc/apt/sources.list.d/rb24.list
         ;;
     trixie | questing | noble)
-        distro="trixie"
+         echo 'deb https://apt.rb24.com/ trixie main' > /etc/apt/sources.list.d/rb24.list
         ;;
 esac
 log_message "Setting repository distribution to ${distro}"

--- a/bash/feeders/airnavradar.sh
+++ b/bash/feeders/airnavradar.sh
@@ -57,7 +57,7 @@ case $RECEIVER_OS_CODE_NAME in
     bookworm)
         echo 'deb https://apt.rb24.com/ bookworm main' > /etc/apt/sources.list.d/rb24.list
         ;;
-    noble)
+    trixie | questing | noble)
         distro="trixie"
         ;;
 esac

--- a/bash/feeders/airplaneslive.sh
+++ b/bash/feeders/airplaneslive.sh
@@ -44,7 +44,7 @@ whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
 if [[ ! -d $RECEIVER_BUILD_DIRECTORY/airplaneslive ]]; then
     log_message "Creating the airplanes.live build directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/airplaneslive 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/airplaneslive 2>&1 | log_pipe
     echo ""
 fi
 log_message "Entering the airplanes.live build directory"
@@ -52,7 +52,7 @@ cd $RECEIVER_BUILD_DIRECTORY/airplaneslive
 
 log_message "Downloading the airplanes.live client installation script"
 echo ""
-wget -v -O $RECEIVER_BUILD_DIRECTORY/airplaneslive/install.sh https://raw.githubusercontent.com/airplanes-live/feed/main/install.sh 2>&1 | tee -a $RECEIVER_LOG_FILE
+wget -v -O $RECEIVER_BUILD_DIRECTORY/airplaneslive/install.sh https://raw.githubusercontent.com/airplanes-live/feed/main/install.sh 2>&1 | log_pipe
 
 log_message "Executing the airplanes.live client installation script"
 echo ""

--- a/bash/feeders/flightradar24.sh
+++ b/bash/feeders/flightradar24.sh
@@ -31,7 +31,7 @@ log_heading "Begining the FlightRadar24 client installation process"
 if [[ ! -d $RECEIVER_BUILD_DIRECTORY/flightradar24 ]]; then
     log_message "Creating the FlightRadar24 build directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/flightradar24 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/flightradar24 2>&1 | log_pipe
     echo ""
 fi
 log_message "Entering the FlightRadar24 build directory"
@@ -39,7 +39,7 @@ cd $RECEIVER_BUILD_DIRECTORY/flightradar24
 
 log_message "Downloading the airplanes.live client installation script"
 echo ""
-wget -v -O $RECEIVER_BUILD_DIRECTORY/flightradar24/install.sh https://fr24.com/install.sh 2>&1 | tee -a $RECEIVER_LOG_FILE
+wget -v -O $RECEIVER_BUILD_DIRECTORY/flightradar24/install.sh https://fr24.com/install.sh 2>&1 | log_pipe
 echo ""
 
 log_message "Executing the airplanes.live client installation script"

--- a/bash/feeders/flyitalyadsb.sh
+++ b/bash/feeders/flyitalyadsb.sh
@@ -36,7 +36,7 @@ whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
 if [[ ! -d $RECEIVER_BUILD_DIRECTORY/flyitalyadsb ]]; then
     log_message "Creating the Fly Italy ADS-B build directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/flyitalyadsb 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/flyitalyadsb 2>&1 | log_pipe
     echo ""
 fi
 log_message "Entering the Fly Italy ADS-B build directory"
@@ -44,7 +44,7 @@ cd $RECEIVER_BUILD_DIRECTORY/flyitalyadsb
 
 log_message "Downloading the Fly Italy ADS-B installation script"
 echo ""
-wget -v -O $RECEIVER_BUILD_DIRECTORY/flyitalyadsb/install.sh https://raw.githubusercontent.com/flyitalyadsb/fly-italy-adsb/master/install.sh 2>&1 | tee -a $RECEIVER_LOG_FILE
+wget -v -O $RECEIVER_BUILD_DIRECTORY/flyitalyadsb/install.sh https://raw.githubusercontent.com/flyitalyadsb/fly-italy-adsb/master/install.sh 2>&1 | log_pipe
 log_message "Executing the Fly Italy ADS-B feeder installation script"
 echo ""
 sudo bash $RECEIVER_BUILD_DIRECTORY/flyitalyadsb/install.sh
@@ -56,7 +56,7 @@ if whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
             12 78; then
     log_message "Downloading the Fly Italy ADS-B updater script"
     echo ""
-    wget -v -O $RECEIVER_BUILD_DIRECTORY/flyitalyadsb/install_updater.sh https://raw.githubusercontent.com/flyitalyadsb/mlat-client/master/scripts/install_updater.sh 2>&1 | tee -a $RECEIVER_LOG_FILE
+    wget -v -O $RECEIVER_BUILD_DIRECTORY/flyitalyadsb/install_updater.sh https://raw.githubusercontent.com/flyitalyadsb/mlat-client/master/scripts/install_updater.sh 2>&1 | log_pipe
     log_message "Executing the Fly Italy ADS-B feeder updater script"
     echo ""
     sudo bash $RECEIVER_BUILD_DIRECTORY/flyitalyadsb/install_updater.sh

--- a/bash/feeders/openskynetwork.sh
+++ b/bash/feeders/openskynetwork.sh
@@ -42,7 +42,7 @@ if ! grep -q "^deb .*opensky." /etc/apt/sources.list /etc/apt/sources.list.d/*; 
     if [[ ! -d $RECEIVER_BUILD_DIRECTORY/openskynetwork ]]; then
         log_message "Creating the OpenSky Network build directory"
         echo ""
-        mkdir -v $RECEIVER_BUILD_DIRECTORY/openskynetwork 2>&1 | tee -a $RECEIVER_LOG_FILE
+        mkdir -v $RECEIVER_BUILD_DIRECTORY/openskynetwork 2>&1 | log_pipe
         echo ""
     fi
     log_message "Entering the OpenSky Network build directory"
@@ -50,8 +50,8 @@ if ! grep -q "^deb .*opensky." /etc/apt/sources.list /etc/apt/sources.list.d/*; 
 
     log_message "Downloading and adding the OpenSky Network apt repository GPG key"
     echo ""
-    wget -v -O $RECEIVER_BUILD_DIRECTORY/openskynetwork/opensky.gpg.pub https://opensky-network.org/files/firmware/opensky.gpg.pub 2>&1 | tee -a $RECEIVER_LOG_FILE
-    wget -q -O - https://opensky-network.org/files/firmware/opensky.gpg.pub | sudo apt-key add - 2>&1 | tee -a $RECEIVER_LOG_FILE
+    wget -v -O $RECEIVER_BUILD_DIRECTORY/openskynetwork/opensky.gpg.pub https://opensky-network.org/files/firmware/opensky.gpg.pub 2>&1 | log_pipe
+    wget -q -O - https://opensky-network.org/files/firmware/opensky.gpg.pub | sudo apt-key add - 2>&1 | log_pipe
     echo ""
     log_message "Adding the OpenSky Network apt repository"
     sudo bash -c "echo deb https://opensky-network.org/repos/debian opensky custom > /etc/apt/sources.list.d/opensky.list"
@@ -66,7 +66,7 @@ log_heading "Installing the OpenSky Network feeder package"
 
 log_message "Downloading the latest package lists for all enabled repositories and PPAs"
 echo ""
-sudo apt-get update 2>&1 | tee -a $RECEIVER_LOG_FILE
+sudo apt-get update 2>&1 | log_pipe
 echo ""
 log_message "Installing the OpenSky Network fedder package using apt"
 echo ""

--- a/bash/feeders/piaware.sh
+++ b/bash/feeders/piaware.sh
@@ -105,7 +105,7 @@ cd $RECEIVER_BUILD_DIRECTORY/piaware_builder
 log_message "Determining which piaware_builder build strategy should be use"
 distro="bookworm"
 case $RECEIVER_OS_CODE_NAME in
-    bullseye | jammy)
+    jammy)
         distro="bullseye"
         ;;
     bookworm)

--- a/bash/feeders/piaware.sh
+++ b/bash/feeders/piaware.sh
@@ -61,6 +61,7 @@ check_package python3-pip
 check_package python3-setuptools
 check_package python3-venv
 check_package python3-wheel
+check_package rsyslog
 check_package tcl-dev
 check_package tcl-tls
 check_package tcl8.6-dev

--- a/bash/feeders/piaware.sh
+++ b/bash/feeders/piaware.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 
-# THE FLIGHTAWARE PIAWARE CLIENT SETUP SCRIPT
-
-# JPROCHAZKA/PIAWARE_BUILDER REPOSITORY
-# -------------------------------------------------------------------------------------
-# I submitted a fix to support Debian Trixie and Ubuntu Noble Numbat to FlightAware's
-# piaware_builder repository. Until the changes are merged into their Git reposiory
-# the installation will be done using the fork I created along with the branch which
-# contains the changes needed in order to build the package.
-#
-# https://github.com/flightaware/piaware_builder/pull/26
-
-
 ## PRE INSTALLATION OPERATIONS
 
 source $RECEIVER_BASH_DIRECTORY/variables.sh
@@ -96,8 +84,8 @@ else
     echo ""
 
     # --- START TEMPORARY NOBLE FIX ---
-    if [[ "${RECEIVER_OS_CODE_NAME}" == "noble" ]]; then
-        git clone -b trixie https://github.com/jprochazka/piaware_builder.git 2>&1 | log_pipe
+    if [[ "${RECEIVER_OS_CODE_NAME}" == "noble" || "${RECEIVER_OS_CODE_NAME}" == "trixie" || "${RECEIVER_OS_CODE_NAME}" == "questing" ]]; then
+        git clone -b dev https://github.com/flightaware/piaware_builder.git 2>&1 | log_pipe
     else
         git clone https://github.com/flightaware/piaware_builder.git 2>&1 | log_pipe
     fi
@@ -123,7 +111,7 @@ case $RECEIVER_OS_CODE_NAME in
     bookworm)
         distro="bookworm"
         ;;
-    noble)
+    trixie | questing | noble)
         distro="trixie"
         ;;
 esac

--- a/bash/feeders/piaware.sh
+++ b/bash/feeders/piaware.sh
@@ -83,11 +83,11 @@ if [[ -d $RECEIVER_BUILD_DIRECTORY/piaware_builder && -d $RECEIVER_BUILD_DIRECTO
     cd $RECEIVER_BUILD_DIRECTORY/piaware_builder
     log_message "Updating the local piaware_builder git repository"
     echo ""
-    git pull 2>&1 | tee -a $RECEIVER_LOG_FILE
+    git pull 2>&1 | log_pipe
 else
     log_message "Creating the FlightAware piaware_builder build directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/piaware_builder 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/piaware_builder 2>&1 | log_pipe
     echo ""
     log_message "Entering the ADS-B Receiver Project build directory"
     cd $RECEIVER_BUILD_DIRECTORY
@@ -96,12 +96,12 @@ else
 
     # --- START TEMPORARY NOBLE FIX ---
     if [[ "${RECEIVER_OS_CODE_NAME}" == "noble" ]]; then
-        git clone -b trixie https://github.com/jprochazka/piaware_builder.git 2>&1 | tee -a $RECEIVER_LOG_FILE
+        git clone -b trixie https://github.com/jprochazka/piaware_builder.git 2>&1 | log_pipe
     else
-        git clone https://github.com/flightaware/piaware_builder.git 2>&1 | tee -a $RECEIVER_LOG_FILE
+        git clone https://github.com/flightaware/piaware_builder.git 2>&1 | log_pipe
     fi
 
-    #git clone https://github.com/flightaware/piaware_builder.git 2>&1 | tee -a $RECEIVER_LOG_FILE
+    #git clone https://github.com/flightaware/piaware_builder.git 2>&1 | log_pipe
     # --- END TEMPORARY NOBLE FIX ---
 fi
 
@@ -130,17 +130,17 @@ log_message "Setting distribution to build for to ${distro}"
 
 log_message "Executing the FlightAware PiAware client build script"
 echo ""
-./sensible-build.sh $distro 2>&1 | tee -a $RECEIVER_LOG_FILE
+./sensible-build.sh $distro 2>&1 | log_pipe
 echo ""
 log_message "Entering the FlightAware PiAware client build directory"
 cd $RECEIVER_BUILD_DIRECTORY/piaware_builder/package-${distro}
 log_message "Building the FlightAware PiAware client package"
 echo ""
-dpkg-buildpackage -b 2>&1 | tee -a $RECEIVER_LOG_FILE
+dpkg-buildpackage -b 2>&1 | log_pipe
 echo ""
 log_message "Installing the FlightAware PiAware client package"
 echo ""
-sudo dpkg -i $RECEIVER_BUILD_DIRECTORY/piaware_builder/piaware_*.deb 2>&1 | tee -a $RECEIVER_LOG_FILE
+sudo dpkg -i $RECEIVER_BUILD_DIRECTORY/piaware_builder/piaware_*.deb 2>&1 | log_pipe
 echo ""
 
 log_message "Checking that the FlightAware PiAware client package was installed properly"
@@ -159,12 +159,12 @@ else
     if [[ ! -d $RECEIVER_BUILD_DIRECTORY/package-archive ]]; then
         log_message "Creating the package archive directory"
         echo ""
-        mkdir -v $RECEIVER_BUILD_DIRECTORY/package-archive 2>&1 | tee -a $RECEIVER_LOG_FILE
+        mkdir -v $RECEIVER_BUILD_DIRECTORY/package-archive 2>&1 | log_pipe
         echo ""
     fi
     log_message "Copying the FlightAware PiAware client binary package into the archive directory"
     echo ""
-    cp -vf $RECEIVER_BUILD_DIRECTORY/piaware_builder/*.deb $RECEIVER_BUILD_DIRECTORY/package-archive/ 2>&1 | tee -a $RECEIVER_LOG_FILE
+    cp -vf $RECEIVER_BUILD_DIRECTORY/piaware_builder/*.deb $RECEIVER_BUILD_DIRECTORY/package-archive/ 2>&1 | log_pipe
 fi
 
 

--- a/bash/feeders/planefinder.sh
+++ b/bash/feeders/planefinder.sh
@@ -30,7 +30,7 @@ log_heading "Installing packages needed to fulfill PlaneFinder client dependenci
 
 check_package wget
 
-case "${RECIEVER_CPU_ARCHITECTURE}" in
+case "${RECEIVER_CPU_ARCHITECTURE}" in
     "aarch64")
         sudo dpkg --add-architecture armhf
         check_package libc6:armhf
@@ -45,15 +45,12 @@ log_heading "Begining the PlaneFinder client installation process"
 
 
 log_message "Determining which Debian package to install"
-case "${RECIEVER_CPU_ARCHITECTURE}" in
+case "${RECEIVER_CPU_ARCHITECTURE}" in
     "armv7l"|"armv6l"|"aarch64")
         package_name="pfclient_${pfclient_current_version_armhf}_armhf.deb"
         ;;
     "x86_64")
         package_name="pfclient_${pfclient_current_version_amd64}_amd64.deb"
-        ;;
-    "i386")
-        package_name="pfclient_${pfclient_current_version_amd64}_i386.deb"
         ;;
     *)
         echo ""
@@ -82,23 +79,23 @@ cd $RECEIVER_BUILD_DIRECTORY/planefinder
 
 log_message "Downloading the appropriate PlaneFinder client Debian package"
 echo ""
-wget -v -O $RECEIVER_BUILD_DIRECTORY/planefinder/$package_name http://client.planefinder.net/$package_name 2>&1 | tee -a $RECEIVER_LOG_FILE
+wget -v -O $RECEIVER_BUILD_DIRECTORY/planefinder/$package_name http://client.planefinder.net/$package_name 2>&1 | log_pipe
 echo ""
 
 log_message "Installing the PlaneFinder Client Debian package"
 echo -e ""
-sudo dpkg -i $RECEIVER_BUILD_DIRECTORY/planefinder/$package_name 2>&1 | tee -a $RECEIVER_LOG_FILE
+sudo dpkg -i $RECEIVER_BUILD_DIRECTORY/planefinder/$package_name 2>&1 | log_pipe
 echo ""
 
 if [[ ! -d $RECEIVER_BUILD_DIRECTORY/package-archive ]]; then
     log_message "Creating the package archive directory"
     echo ""
-    mkdir -v $RECEIVER_BUILD_DIRECTORY/package-archive 2>&1 | tee -a $RECEIVER_LOG_FILE
+    mkdir -v $RECEIVER_BUILD_DIRECTORY/package-archive 2>&1 | log_pipe
     echo ""
 fi
 log_message "Copying the PlaneFinder client Debian package into the archive directory"
 echo ""
-cp -vf $RECEIVER_BUILD_DIRECTORY/planefinder/$package_name $RECEIVER_BUILD_DIRECTORY/package-archive/ 2>&1 | tee -a $RECEIVER_LOG_FILE
+cp -vf $RECEIVER_BUILD_DIRECTORY/planefinder/$package_name $RECEIVER_BUILD_DIRECTORY/package-archive/ 2>&1 | log_pipe
 echo ""
 
 

--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -4,16 +4,16 @@
 
 # Log a <message> to the log file
 function log_to_file() {
+    local time_stamp=''
     if [[ "${RECEIVER_LOGGING_ENABLED}" == "true" ]]; then
-        time_stamp=''
-        if [[ -z $2 || "${2}" == "true" ]]; then
+        if [[ -z "$2" || "${2}" == "true" ]]; then
             printf -v time_stamp '[%(%Y-%m-%d %H:%M:%S)T]' -1
         fi
 
-        if [[ ! -z $3 && "${3}" == "inline" ]]; then
-            printf "${time_stamp} ${1}" >> $RECEIVER_LOG_FILE
+        if [[ -n "$3" && "${3}" == "inline" ]]; then
+            printf "%s %s" "${time_stamp}" "${1}" >> "${RECEIVER_LOG_FILE}"
         else
-            echo "${time_stamp} ${1}" >> $RECEIVER_LOG_FILE
+            printf "%s %s\n" "${time_stamp}" "${1}" >> "${RECEIVER_LOG_FILE}"
         fi
     fi
 }
@@ -51,13 +51,13 @@ function log_alert_message() {
     echo -e "${display_alert_message}  ${1}${display_default}"
 }
 
-# Logs an title "HEADING" to the console
+# Logs a title "HEADING" to the console
 function log_title_heading() {
     log_to_file "${1}"
     echo -e "${display_title_heading}  ${1}${display_default}"
 }
 
-# Logs an title "MESSAGE" to the console
+# Logs a title "MESSAGE" to the console
 function log_title_message() {
     log_to_file "${1}"
     echo -e "${display_title_message}  ${1}${display_default}"
@@ -75,50 +75,62 @@ function log_warning_message() {
     echo -e "${display_warning_message}  ${1}${display_default}"
 }
 
+# Logs an inline "MESSAGE" to the console
 function log_message_inline() {
     log_to_file "${1}" "true" "inline"
-    printf "${display_message}  ${1}${display_default}"
+    printf "%s  %s%s" "${display_message}" "${1}" "${display_default}"
 }
 
+# Logs an inline failure indicator to the console
 function log_false_inline() {
     log_to_file "${1}" "false"
     echo -e "${display_false_inline} ${1}${display_default}"
 }
 
+# Logs an inline success indicator to the console
 function log_true_inline() {
     log_to_file "${1}" "false"
     echo -e "${display_true_inline} ${1}${display_default}"
+}
+
+# Pipe command output to the console and optionally append to the log file
+function log_pipe() {
+    if [[ "${RECEIVER_LOGGING_ENABLED}" == "true" ]]; then
+        tee -a "${RECEIVER_LOG_FILE}"
+    else
+        cat
+    fi
 }
 
 
 ## CHECK IF THE SUPPLIED PACKAGE IS INSTALLED AND IF NOT ATTEMPT TO INSTALL IT
 
 function check_package() {
-    attempt=1
-    max_attempts=5
-    wait_time=5
+    local attempt=1
+    local max_attempts=5
+    local wait_time=5
 
-    while (( $attempt -le `(($max_attempts + 1))` )); do
-        if [[ $attempt > $max_attempts ]]; then
-           log_alert_heading "INSTALLATION HALTED"
-           log_alert_message "Unable to install a required package"
-           log_alert_message "The package $1 could not be installed in ${max_attempts} attempts"
+    while (( attempt <= max_attempts + 1 )); do
+        if [[ $attempt -gt $max_attempts ]]; then
+            log_alert_heading "INSTALLATION HALTED"
+            log_alert_message "Unable to install a required package"
+            log_alert_message "The package ${1} could not be installed in ${max_attempts} attempts"
             exit 1
         fi
 
-        log_message_inline "Checking if the package $1 is installed"
-        if [[ $(dpkg-query -W -f='${STATUS}' $1 2>/dev/null | grep -c "ok installed") = 0 ]]; then
-            if [[ $attempt > 1 ]]; then
-                log_alert_message "Inastallation attempt failed"
-                log_alert_message "Will attempt to Install the package $1 again in ${wait_time} seconds (attempt ${attempt} of ${max_attempts})"
-                sleep $wait_time
+        log_message_inline "Checking if the package ${1} is installed"
+        if [[ $(dpkg-query -W -f='${STATUS}' "${1}" 2>/dev/null | grep -c "ok installed") -eq 0 ]]; then
+            if [[ $attempt -gt 1 ]]; then
+                log_alert_message "Installation attempt failed"
+                log_alert_message "Will attempt to install the package ${1} again in ${wait_time} seconds (attempt ${attempt} of ${max_attempts})"
+                sleep "${wait_time}"
             else
                 log_false_inline "[NOT INSTALLED]"
                 log_message "Installing the package ${1}"
             fi
             echo ""
-            attempt=$((attempt+1))
-            sudo apt-get install -y $1 #2>&1 | tee -a $RECEIVER_LOG_FILE
+            (( attempt++ ))
+            sudo apt-get install -y "${1}" 2>&1 | log_pipe
             echo ""
         else
             log_true_inline "[OK]"
@@ -131,7 +143,7 @@ function check_package() {
 ## BLACKLIST DVB-T DRIVERS FOR RTL-SDR DEVICES
 
 function blacklist_modules() {
-    if [[ ! -f /etc/modprobe.d/rtlsdr-blacklist.conf || `cat /etc/modprobe.d/rtlsdr-blacklist.conf | wc -l` < 9 ]]; then
+    if [[ ! -f /etc/modprobe.d/rtlsdr-blacklist.conf || $(wc -l < /etc/modprobe.d/rtlsdr-blacklist.conf) -lt 9 ]]; then
         log_message "Blacklisting unwanted RTL-SDR kernel modules so they are not loaded"
         sudo tee /etc/modprobe.d/rtlsdr-blacklist.conf  > /dev/null <<EOF
 blacklist dvb_usb_v2
@@ -155,41 +167,71 @@ EOF
 # Use sed to locate the "KEY" then replace the "VALUE", the portion after the equals sign, in the specified "FILE"
 # This function should work with any configuration file with settings formated as KEY="VALUE"
 function change_config() {
-    sudo sed -i -e "s/\($1 *= *\).*/\1\"$2\"/" $3
+    sudo sed -i -e "s/\($1 *= *\).*/\1\"$2\"/" "$3"
 }
 
 # Use sed to locate the "KEY" then read the "VALUE", the portion after the equals sign, in the specified "FILE"
 # This function should work with any configuration file with settings formated as KEY="VALUE"
 function get_config() {
-    setting=`sed -n "/^$1 *= *\"\(.*\)\"$/s//\1/p" $2`
+    local setting
+    setting=$(sed -n "/^$1 *= *\"\(.*\)\"$/s//\1/p" "$2")
     if [[ "${setting}" == "" ]]; then
-        setting=`sed -n "/^$1 *= *\(.*\)$/s//\1/p" $2`
+        setting=$(sed -n "/^$1 *= *\(.*\)$/s//\1/p" "$2")
     fi
-    echo $setting
+    echo "${setting}"
 }
 
 
 ## ASSIGN DEVICES TO DECODERS
 
+function ask_device_number() {
+    local decoder_name="$1"
+    local var_name="$2"
+    local default_value="${3:-}"
+    local title="Enter the ${decoder_name} RTL-SDR Device Number"
+    local value=""
+    log_message "Asking the user to assign a RTL-SDR device number to ${decoder_name}"
+    while [[ -z "${value}" ]]; do
+        value=$(whiptail --backtitle "Decoder Configuration" \
+                         --title "${title}" \
+                         --inputbox "\nEnter the RTL-SDR device number to assign to ${decoder_name}." \
+                         8 78 \
+                         "${default_value}" 3>&1 1>&2 2>&3)
+        if [[ $? -ne 0 ]]; then
+            exit 1
+        fi
+        title="Enter the ${decoder_name} RTL-SDR Device Number (REQUIRED)"
+    done
+    declare -g "${var_name}=${value}"
+}
+
 function ask_for_device_assignments() {
+    local decoder_being_installed="$1"
+    local decoder_count=1
+    local acars_decoder_installed="false"
+    local adsb_decoder_installed="false"
+    local uat_decoder_installed="false"
+    local vdlm2_decoder_installed="false"
+    local exec_start
+    local receiver_options
+    local device_assigned_to_acars_decoder=""
+    local device_assigned_to_adsb_decoder=""
+    local device_assigned_to_uat_decoder=""
+    local device_assigned_to_vdlm2_decoder=""
+
     log_heading "Gather information required to configure the decoder(s)"
 
-    decoder_being_installed=$1
-    decoder_count=1
-
     log_message "Checking if an ACARS decoder is installed"
-    acars_decoder_installed="false"
     if [[ -f /usr/local/bin/acarsdec ]]; then
         log_message "The ACARSDEC decoder appears to be installed"
         acars_decoder_installed="true"
         RECEIVER_ACARS_DECODER_SOFTWARE="acarsdec"
     fi
     if [[ "${acars_decoder_installed}" == "true" && "${RECEIVER_ACARS_DECODER_SOFTWARE}" != "${decoder_being_installed}" ]]; then
-        decoder_count=$((decoder_count+1))
+        (( decoder_count++ ))
     fi
 
     log_message "Checking if an ADS-B decoder is installed"
-    adsb_decoder_installed="false"
     if [[ $(dpkg-query -W -f='${STATUS}' dump1090-fa 2>/dev/null | grep -c "ok installed") -eq 1 ]]; then
         log_message "The FlightAware dump1090 decoder appears to be installed"
         adsb_decoder_installed="true"
@@ -201,22 +243,20 @@ function ask_for_device_assignments() {
         RECEIVER_ADSB_DECODER_SOFTWARE="readsb"
     fi
     if [[ "${adsb_decoder_installed}" == "true" && "${RECEIVER_ADSB_DECODER_SOFTWARE}" != "${decoder_being_installed}" ]]; then
-        decoder_count=$((decoder_count+1))
+        (( decoder_count++ ))
     fi
 
     log_message "Checking if a UAT decoder is installed"
-    uat_decoder_installed="false"
     if [[ $(dpkg-query -W -f='${STATUS}' dump978-fa 2>/dev/null | grep -c "ok installed") -eq 1 ]]; then
         log_message "The FlightAware dump978 decoder appears to be installed"
         uat_decoder_installed="true"
         RECEIVER_UAT_DECODER_SOFTWARE="dump978-fa"
     fi
     if [[ "${uat_decoder_installed}" == "true" && "${RECEIVER_UAT_DECODER_SOFTWARE}" != "${decoder_being_installed}" ]]; then
-        decoder_count=$((decoder_count+1))
+        (( decoder_count++ ))
     fi
 
     log_message "Checking if a VDL Mode 2 decoder is installed"
-    vdlm2_decoder_installed="false"
     if [[ -f /usr/local/bin/dumpvdl2 ]]; then
         log_message "The dumpvdl2 decoder appears to be installed"
         vdlm2_decoder_installed="true"
@@ -228,10 +268,10 @@ function ask_for_device_assignments() {
         RECEIVER_VDLM2_DECODER_SOFTWARE="vdlm2dec"
     fi
     if [[ "${vdlm2_decoder_installed}" == "true" && "${RECEIVER_VDLM2_DECODER_SOFTWARE}" != "${decoder_being_installed}" ]]; then
-        decoder_count=$((decoder_count+1))
+        (( decoder_count++ ))
     fi
 
-    if [[ $decoder_count > 1 ]]; then
+    if [[ $decoder_count -gt 1 ]]; then
         log_message "Informing the user that existing decoder(s) appears to be installed"
         whiptail --backtitle "Decoder Configuration" \
                 --title "RTL-SDR Dongle Assignments" \
@@ -241,132 +281,54 @@ function ask_for_device_assignments() {
         if [[ "${decoder_being_installed}" == "acarsdec" || "${acars_decoder_installed}" == "true" && "${RECEIVER_ACARS_DECODER_SOFTWARE}" == "acarsdec" ]]; then
             if [[ "${acars_decoder_installed}" == "true" ]]; then
                 log_message "Determining which device is currently assigned to ACARSDEC"
-                exec_start=`get_config "ExecStart" "/etc/systemd/system/acarsdec.service"`
-                device_assigned_to_acars_decoder=`echo $exec_start | grep -o -P '(?<=-r )[0-9]+'`
+                exec_start=$(get_config "ExecStart" "/etc/systemd/system/acarsdec.service")
+                device_assigned_to_acars_decoder=$(echo "${exec_start}" | grep -o -P '(?<=-r )[0-9]+')
             fi
-            log_message "Asking the user to assign a RTL-SDR device number to ACARSDEC"
-            acars_device_number_title="Enter the ACARSDEC RTL-SDR Device Number"
-            while [[ -z $RECEIVER_DEVICE_ASSIGNED_TO_ACARS_DECODER ]]; do
-                RECEIVER_DEVICE_ASSIGNED_TO_ACARS_DECODER=$(whiptail --backtitle "Decoder Configuration" \
-                                                                     --title "${acars_device_number_title}" \
-                                                                     --inputbox "\nEnter the RTL-SDR device number to assign to ACARSDEC." \
-                                                                     8 78 \
-                                                                     "${device_assigned_to_acars_decoder}" 3>&1 1>&2 2>&3)
-                exit_status=$?
-                if [[ $exit_status != 0 ]]; then
-                    exit 1
-                fi
-                acars_device_number_title="Enter the ACARSDEC RTL-SDR Device Number (REQUIRED)"
-            done
+            ask_device_number "ACARSDEC" "RECEIVER_DEVICE_ASSIGNED_TO_ACARS_DECODER" "${device_assigned_to_acars_decoder}"
         fi
 
         if [[ "${decoder_being_installed}" == "dump1090-fa" || "${adsb_decoder_installed}" == "true" && "${RECEIVER_ADSB_DECODER_SOFTWARE}" == "dump1090-fa" ]]; then
             if [[ "${adsb_decoder_installed}" == "true" ]]; then
                 log_message "Determining which device is currently assigned to dump1090-fa"
-                device_assigned_to_adsb_decoder=`get_config "RECEIVER_SERIAL" "/etc/default/dump1090-fa"`
+                device_assigned_to_adsb_decoder=$(get_config "RECEIVER_SERIAL" "/etc/default/dump1090-fa")
             fi
-            log_message "Asking the user to assign a RTL-SDR device number to dump1090-fa"
-            adsb_device_number_title="Enter the dump1090-fa RTL-SDR Device Number"
-            while [[ -z $RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER ]]; do
-                RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER=$(whiptail --backtitle "Decoder Configuration" \
-                                                                    --title "${adsb_device_number_title}" \
-                                                                    --inputbox "\nEnter the RTL-SDR device number to assign to dump1090-fa." \
-                                                                    8 78 \
-                                                                    "${device_assigned_to_adsb_decoder}" 3>&1 1>&2 2>&3)
-                exit_status=$?
-                if [[ $exit_status != 0 ]]; then
-                    exit 1
-                fi
-                adsb_device_number_title="Enter the dump1090-fa RTL-SDR Device Number (REQUIRED)"
-            done
+            ask_device_number "dump1090-fa" "RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER" "${device_assigned_to_adsb_decoder}"
         fi
 
         if [[ "${decoder_being_installed}" == "dump978-fa" || "${uat_decoder_installed}" == "true" && "${RECEIVER_UAT_DECODER_SOFTWARE}" == "dump978-fa" ]]; then
             if [[ "${uat_decoder_installed}" == "true" ]]; then
                 log_message "Determining which device is currently assigned to dump978-fa"
-                receiver_options=`get_config "RECEIVER_OPTIONS" "/etc/default/dump978-fa"`
-                device_assigned_to_uat_decoder=`echo $receiver_options | grep -o -P '(?<=serial=)[0-9]+'`
+                receiver_options=$(get_config "RECEIVER_OPTIONS" "/etc/default/dump978-fa")
+                device_assigned_to_uat_decoder=$(echo "${receiver_options}" | grep -o -P '(?<=serial=)[0-9]+')
             fi
-            log_message "Asking the user to assign a RTL-SDR device number to dump978-fa"
-            uat_device_number_title="Enter the dump978-fa RTL-SDR Device Number"
-            while [[ -z $RECEIVER_DEVICE_ASSIGNED_TO_UAT_DECODER ]] ; do
-                RECEIVER_DEVICE_ASSIGNED_TO_UAT_DECODER=$(whiptail --backtitle "Decoder Configuration" \
-                                                                   --title "${uat_device_number_title}" \
-                                                                   --inputbox "\nEnter the RTL-SDR device number to assign to dump978-fa." \
-                                                                   8 78 \
-                                                                   "${device_assigned_to_uat_decoder}" 3>&1 1>&2 2>&3)
-                exit_status=$?
-                if [[ $exit_status != 0 ]]; then
-                    exit 1
-                fi
-                uat_device_number_title="Enter the dump978-fa RTL-SDR Device Number (REQUIRED)"
-            done
+            ask_device_number "dump978-fa" "RECEIVER_DEVICE_ASSIGNED_TO_UAT_DECODER" "${device_assigned_to_uat_decoder}"
         fi
 
         if [[ "${decoder_being_installed}" == "dumpvdl2" || "${vdlm2_decoder_installed}" == "true" && "${RECEIVER_VDLM2_DECODER_SOFTWARE}" == "dumpvdl2" ]]; then
             if [[ "${vdlm2_decoder_installed}" == "true" ]]; then
                 log_message "Determining which device is currently assigned to dumpvdl2"
-                exec_start=`get_config "ExecStart" "/etc/systemd/system/dumpvdl2.service"`
-                device_assigned_to_vdlm2_decoder=`echo $exec_start | grep -o -P '(?<=--rtlsdr )[0-9]+'`
+                exec_start=$(get_config "ExecStart" "/etc/systemd/system/dumpvdl2.service")
+                device_assigned_to_vdlm2_decoder=$(echo "${exec_start}" | grep -o -P '(?<=--rtlsdr )[0-9]+')
             fi
-            log_message "Asking the user to assign a RTL-SDR device number to dumpvdl2"
-            vdlm2_device_number_title="Enter the dumpvdl2 RTL-SDR Device Number"
-            while [[ -z $RECEIVER_DEVICE_ASSIGNED_TO_VDLM2_DECODER ]]; do
-                RECEIVER_DEVICE_ASSIGNED_TO_VDLM2_DECODER=$(whiptail --backtitle "Decoder Configuration" \
-                                                                     --title "${vdlm2_device_number_title}" \
-                                                                     --inputbox "Enter the RTL-SDR device number to assign to dumpvdl2." \
-                                                                     8 78 \
-                                                                     "${device_assigned_to_vdlm2_decoder}" 3>&1 1>&2 2>&3)
-                exit_status=$?
-                if [[ $exit_status != 0 ]]; then
-                    exit 1
-                fi
-                vdlm2_device_number_title="Enter the dumpvdl2 RTL-SDR Device Number (REQUIRED)"
-            done
+            ask_device_number "dumpvdl2" "RECEIVER_DEVICE_ASSIGNED_TO_VDLM2_DECODER" "${device_assigned_to_vdlm2_decoder}"
         fi
 
         if [[ "${decoder_being_installed}" == "readsb" || "${adsb_decoder_installed}" == "true" && "${RECEIVER_ADSB_DECODER_SOFTWARE}" == "readsb" ]]; then
-            if [[  "${adsb_decoder_installed}" == "true" ]]; then
+            if [[ "${adsb_decoder_installed}" == "true" ]]; then
                 log_message "Determining which device is currently assigned to Readsb"
-                receiver_options=`get_config "RECEIVER_OPTIONS" "/etc/default/readsb"`
-                device_assigned_to_adsb_decoder=`echo $receiver_options | grep -o -P '(?<=--device )[0-9]+'`
+                receiver_options=$(get_config "RECEIVER_OPTIONS" "/etc/default/readsb")
+                device_assigned_to_adsb_decoder=$(echo "${receiver_options}" | grep -o -P '(?<=--device )[0-9]+')
             fi
-            log_message "Asking the user to assign a RTL-SDR device number to Readsb"
-            adsb_device_number_title="Enter the Readsb RTL-SDR Device Number"
-            while [[ -z $RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER ]]; do
-                RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER=$(whiptail --backtitle "Decoder Configuration" \
-                                                                    --title "${adsb_device_number_title}" \
-                                                                    --inputbox "\nEnter the RTL-SDR device number to assign to Readsb." \
-                                                                    8 78 \
-                                                                    "${device_assigned_to_adsb_decoder}" 3>&1 1>&2 2>&3)
-                exit_status=$?
-                if [[ $exit_status != 0 ]]; then
-                    exit 1
-                fi
-                adsb_device_number_title="Enter the Readsb RTL-SDR Device Number (REQUIRED)"
-            done
+            ask_device_number "Readsb" "RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER" "${device_assigned_to_adsb_decoder}"
         fi
 
         if [[ "${decoder_being_installed}" == "vdlm2dec" || "${vdlm2_decoder_installed}" == "true" && "${RECEIVER_VDLM2_DECODER_SOFTWARE}" == "vdlm2dec" ]]; then
             if [[ "${vdlm2_decoder_installed}" == "true" ]]; then
                 log_message "Determining which device is currently assigned to VDLM2DEC"
-                exec_start=`get_config "ExecStart" "/etc/systemd/system/vdlm2dec.service"`
-                device_assigned_to_vdlm2_decoder=`echo $exec_start | grep -o -P '(?<=-r )[0-9]+'`
+                exec_start=$(get_config "ExecStart" "/etc/systemd/system/vdlm2dec.service")
+                device_assigned_to_vdlm2_decoder=$(echo "${exec_start}" | grep -o -P '(?<=-r )[0-9]+')
             fi
-            log_message "Asking the user to assign a RTL-SDR device number to VDLM2DEC"
-            vdlm2_device_number_title="Enter the VDLM2DEC RTL-SDR Device Number"
-            while [[ -z $RECEIVER_DEVICE_ASSIGNED_TO_VDLM2_DECODER ]]; do
-                RECEIVER_DEVICE_ASSIGNED_TO_VDLM2_DECODER=$(whiptail --backtitle "Decoder Configuration" \
-                                                                     --title "${vdlm2_device_number_title}" \
-                                                                     --inputbox "\nEnter the RTL-SDR device number to assign to VDLM2DEC." \
-                                                                     8 78 \
-                                                                     "${device_assigned_to_vdlm2_decoder}" 3>&1 1>&2 2>&3)
-                exit_status=$?
-                if [[ $exit_status != 0 ]]; then
-                    exit 1
-                fi
-                vdlm2_device_number_title="Enter the ACARSDEC RTL-SDR Device Number (REQUIRED)"
-            done
+            ask_device_number "VDLM2DEC" "RECEIVER_DEVICE_ASSIGNED_TO_VDLM2_DECODER" "${device_assigned_to_vdlm2_decoder}"
         fi
     fi
 }
@@ -375,7 +337,7 @@ function assign_devices_to_decoders() {
 
     log_heading "Configure decoders if more than one is present"
 
-    if [[ ! -z $RECEIVER_DEVICE_ASSIGNED_TO_ACARS_DECODER && "${RECEIVER_ACARS_DECODER_SOFTWARE}" == "acarsdec" ]]; then
+    if [[ -n "${RECEIVER_DEVICE_ASSIGNED_TO_ACARS_DECODER}" && "${RECEIVER_ACARS_DECODER_SOFTWARE}" == "acarsdec" ]]; then
         log_message "Assigning RTL-SDR device number ${RECEIVER_DEVICE_ASSIGNED_TO_ACARS_DECODER} to ACARSDEC"
         sudo sed -i -e "s|\(.*-r \)\([0-9]\+\)\( .*\)|\1${RECEIVER_DEVICE_ASSIGNED_TO_ACARS_DECODER}\3|g" /etc/systemd/system/acarsdec.service
         log_message "Reload systemd units"
@@ -384,17 +346,18 @@ function assign_devices_to_decoders() {
         sudo systemctl restart acarsdec
     fi
 
-    if [[ ! -z $RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER && "${RECEIVER_ADSB_DECODER_SOFTWARE}" == "dump1090-fa" ]]; then
+    if [[ -n "${RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER}" && "${RECEIVER_ADSB_DECODER_SOFTWARE}" == "dump1090-fa" ]]; then
         log_message "Assigning RTL-SDR device number ${RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER} to FlightAware Dump1090"
-        change_config "RECEIVER_SERIAL" $RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER "/etc/default/dump1090-fa"
+        change_config "RECEIVER_SERIAL" "${RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER}" "/etc/default/dump1090-fa"
         log_message "Restarting dump1090-fa"
         sudo systemctl restart dump1090-fa
     fi
 
-    if [[ ! -z $RECEIVER_DEVICE_ASSIGNED_TO_UAT_DECODER && "${RECEIVER_UAT_DECODER_SOFTWARE}" == "dump978-fa" ]]; then
+    if [[ -n "${RECEIVER_DEVICE_ASSIGNED_TO_UAT_DECODER}" && "${RECEIVER_UAT_DECODER_SOFTWARE}" == "dump978-fa" ]]; then
         log_message "Assigning RTL-SDR device number ${RECEIVER_DEVICE_ASSIGNED_TO_UAT_DECODER} to FlightAware Dump978"
-        serial_assigned=$(cat /etc/default/dump978-fa | grep -c "driver=rtlsdr,serial=")
-        if [[ $serial_assigned == 1 ]]; then
+        local serial_assigned
+        serial_assigned=$(grep -c "driver=rtlsdr,serial=" /etc/default/dump978-fa)
+        if [[ $serial_assigned -eq 1 ]]; then
             sudo sed -i -e "s|\(.*driver=rtlsdr,serial=\)\([0-9]\+\)\( .*\)|\1${RECEIVER_DEVICE_ASSIGNED_TO_UAT_DECODER}\3|g" /etc/default/dump978-fa
         else
             sudo sed -i -e "s|driver=rtlsdr|driver=rtlsdr,serial=${RECEIVER_DEVICE_ASSIGNED_TO_UAT_DECODER}|g" /etc/default/dump978-fa
@@ -403,7 +366,7 @@ function assign_devices_to_decoders() {
         sudo systemctl restart dump978-fa
     fi
 
-    if [[ ! -z $RECEIVER_DEVICE_ASSIGNED_TO_VDLM2_DECODER && "${RECEIVER_VDLM2_DECODER_SOFTWARE}" == "dumpvdl2" ]]; then
+    if [[ -n "${RECEIVER_DEVICE_ASSIGNED_TO_VDLM2_DECODER}" && "${RECEIVER_VDLM2_DECODER_SOFTWARE}" == "dumpvdl2" ]]; then
         log_message "Assigning RTL-SDR device number ${RECEIVER_DEVICE_ASSIGNED_TO_VDLM2_DECODER} to dumpvdl2"
         sudo sed -i -e "s|\(.*--rtlsdr \)\([0-9]\+\)\( .*\)|\1${RECEIVER_DEVICE_ASSIGNED_TO_VDLM2_DECODER}\3|g" /etc/systemd/system/dumpvdl2.service
         log_message "Reloading systemd units"
@@ -412,14 +375,14 @@ function assign_devices_to_decoders() {
         sudo systemctl restart dumpvdl2
     fi
 
-    if [[ ! -z $RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER && "${RECEIVER_ADSB_DECODER_SOFTWARE}" == "readsb" ]]; then
+    if [[ -n "${RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER}" && "${RECEIVER_ADSB_DECODER_SOFTWARE}" == "readsb" ]]; then
         log_message "Assigning RTL-SDR device number ${RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER} to Readsb"
         sudo sed -i -e "s|\(.*--device \)\([0-9]\+\)\( .*\)|\1${RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER}\3|g" /etc/default/readsb
         log_message "Restarting Readsb"
         sudo systemctl restart readsb
     fi
 
-    if [[ ! -z $RECEIVER_DEVICE_ASSIGNED_TO_VDLM2_DECODER && "${RECEIVER_VDLM2_DECODER_SOFTWARE}" == "vdlm2dec" ]]; then
+    if [[ -n "${RECEIVER_DEVICE_ASSIGNED_TO_VDLM2_DECODER}" && "${RECEIVER_VDLM2_DECODER_SOFTWARE}" == "vdlm2dec" ]]; then
         log_message "Assigning RTL-SDR device number ${RECEIVER_DEVICE_ASSIGNED_TO_VDLM2_DECODER} to vdlm2dec"
         sudo sed -i -e "s|\(.*-r \)\([0-9]\+\)\( .*\)|\1${RECEIVER_DEVICE_ASSIGNED_TO_VDLM2_DECODER}\3|g" /etc/systemd/system/vdlm2dec.service
         log_message "Reloading systemd units"

--- a/bash/init.sh
+++ b/bash/init.sh
@@ -25,6 +25,9 @@ fi
 
 ## ATTEMPT TO CHANGE AND/OR UPDATE THE REPOSITORY
 
+log_message "Setting Git to ignore permission changes"
+git config core.fileMode false
+
 if [[ "${RECEIVER_DEVELOPMENT_MODE}" != "true" ]]; then
     current_branch=$(git rev-parse --abbrev-ref HEAD)
 
@@ -123,6 +126,9 @@ fi
 
 
 ## INSTALLATION COMPLETE
+
+log_message "Setting Git to notice permission changes"
+git config core.fileMode true
 
 whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
          --title "Software Installation Complete" \

--- a/bash/init.sh
+++ b/bash/init.sh
@@ -2,8 +2,8 @@
 
 ## PRE EXECUTION OPERATIONS
 
-source $RECEIVER_BASH_DIRECTORY/variables.sh
-source $RECEIVER_BASH_DIRECTORY/functions.sh
+source "${RECEIVER_BASH_DIRECTORY}/variables.sh"
+source "${RECEIVER_BASH_DIRECTORY}/functions.sh"
 
 
 ## DISPLAY THE WELCOME SCREEN
@@ -25,8 +25,8 @@ fi
 
 ## ATTEMPT TO CHANGE AND/OR UPDATE THE REPOSITORY
 
-if [[ $RECEIVER_DEVELOPMENT_MODE != "true" ]]; then
-    current_branch=`git rev-parse --abbrev-ref HEAD`
+if [[ "${RECEIVER_DEVELOPMENT_MODE}" != "true" ]]; then
+    current_branch=$(git rev-parse --abbrev-ref HEAD)
 
     clear
     log_project_title
@@ -35,14 +35,14 @@ if [[ $RECEIVER_DEVELOPMENT_MODE != "true" ]]; then
 
     log_heading "Checking out and updating the appropriate branch"
 
-    if [[ `git status --porcelain --untracked-files=no` && `git ls-remote --heads https://github.com/jprochazka/adsb-receiver.git refs/heads/master | wc -l` = 1 ]]; then
+    if [[ $(git status --porcelain --untracked-files=no) && $(git ls-remote --heads https://github.com/jprochazka/adsb-receiver.git refs/heads/master | wc -l) -eq 1 ]]; then
         if whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
                     --title "Stash Changes To Branch ${current_branch}" \
                     --defaultno \
                     --yesno "There appears to be changes to the current branch. In order to switch to or fetch the ${current_branch} branch these changes will need to be stashed. Would you like to stash these changes now?" \
                     14 78; then
             log_message "Stashing changes made to the ${current_branch} branch"
-            git stash 2>&1 | tee -a $RECEIVER_LOG_FILE
+            git stash 2>&1 | log_pipe
             echo ""
         else
             log_alert_heading "INSTALLATION HALTED"
@@ -55,18 +55,18 @@ if [[ $RECEIVER_DEVELOPMENT_MODE != "true" ]]; then
     if [[ "${current_branch}" != "${RECEIVER_PROJECT_BRANCH}" ]]; then
         log_message "Switching to branch ${RECEIVER_PROJECT_BRANCH}"
         echo ""
-        git checkout $RECEIVER_PROJECT_BRANCH 2>&1 | tee -a $RECEIVER_LOG_FILE
+        git checkout "${RECEIVER_PROJECT_BRANCH}" 2>&1 | log_pipe
         echo ""
     fi
 
-    if [[ `git ls-remote --heads https://github.com/jprochazka/adsb-receiver.git refs/heads/$RECEIVER_PROJECT_BRANCH | wc -l` = 1 ]]; then
+    if [[ $(git ls-remote --heads https://github.com/jprochazka/adsb-receiver.git "refs/heads/${RECEIVER_PROJECT_BRANCH}" | wc -l) -eq 1 ]]; then
         log_message "Fetching branch ${RECEIVER_PROJECT_BRANCH} from origin"
         echo ""
-        git fetch origin 2>&1 | tee -a $RECEIVER_LOG_FILE
+        git fetch origin 2>&1 | log_pipe
         echo ""
         log_message "Performing hard reset of branch ${RECEIVER_PROJECT_BRANCH} so it matches origin/${RECEIVER_PROJECT_BRANCH}"
         echo ""
-        git reset --hard origin/$RECEIVER_PROJECT_BRANCH
+        git reset --hard "origin/${RECEIVER_PROJECT_BRANCH}"
     else
         log_message "The branch ${RECEIVER_PROJECT_BRANCH} does not appear to be in origin"
     fi
@@ -74,7 +74,7 @@ if [[ $RECEIVER_DEVELOPMENT_MODE != "true" ]]; then
     log_title_message "-----------------------------------------------------------------------------"
     log_title_heading "Finished fetching the latest version the '${RECEIVER_PROJECT_BRANCH}' branch."
     echo ""
-    read -p "Press enter to continue..." discard
+    if [[ -t 0 ]]; then read -r -p "Press enter to continue..." discard; fi
 fi
 
 
@@ -96,12 +96,12 @@ if whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
 
     log_message "Updating the operating system using apt-get"
     echo ""
-    sudo apt-get -y dist-upgrade 2>&1 | tee -a $RECEIVER_LOG_FILE
+    sudo apt-get -y dist-upgrade 2>&1 | log_pipe
     echo ""
     log_title_message "------------------------------------------------------------------------"
     log_title_heading "Your operating system should now be up to date"
     echo ""
-    read -p "Press enter to continue..." discard
+    if [[ -t 0 ]]; then read -r -p "Press enter to continue..." discard; fi
 fi
 
 
@@ -112,10 +112,11 @@ clear
 log_heading "Executing the script bash/main.sh"
 
 log_message "Executing bash/main"
-bash $RECEIVER_BASH_DIRECTORY/main.sh
-if [[ $? -ne 0 ]] ; then
+bash "${RECEIVER_BASH_DIRECTORY}/main.sh"
+main_exit_code=$?
+if [[ $main_exit_code -ne 0 ]] ; then
     echo ""
-    log_alert_heading "ANY FURTHER SETUP AND/OR INSTALLATION REQUESTS HAVE BEEN TERMINIATED"
+    log_alert_heading "ANY FURTHER SETUP AND/OR INSTALLATION REQUESTS HAVE BEEN TERMINATED"
     echo ""
     exit 1
 fi

--- a/bash/main.sh
+++ b/bash/main.sh
@@ -2,8 +2,33 @@
 
 ## INCLUDE EXTERNAL SCRIPTS
 
-source ${RECEIVER_BASH_DIRECTORY}/variables.sh
-source ${RECEIVER_BASH_DIRECTORY}/functions.sh
+source "${RECEIVER_BASH_DIRECTORY}/variables.sh"
+source "${RECEIVER_BASH_DIRECTORY}/functions.sh"
+
+
+## HELPER FUNCTIONS
+
+function run_installer() {
+    if ! bash "${RECEIVER_BASH_DIRECTORY}/$1"; then
+        exit 1
+    fi
+}
+
+function is_package_installed() {
+    [[ $(dpkg-query -W -f='${STATUS}' "$1" 2>/dev/null | grep -c "ok installed") -eq 1 ]]
+}
+
+function ask_reinstall() {
+    local title="$1" msg="$2" height="$3" width="$4" var_name="$5"
+    whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
+             --title "${title}" \
+             --defaultno \
+             --yesno "${msg}" \
+             "${height}" "${width}"
+    if [[ $? -eq 0 ]]; then
+        printf -v "${var_name}" "true"
+    fi
+}
 
 
 ## ADS-B DECODERS
@@ -11,40 +36,26 @@ source ${RECEIVER_BASH_DIRECTORY}/functions.sh
 adsb_decoder_installed="false"
 install_adsb_decoder="false"
 
-if [[ $(dpkg-query -W -f='${STATUS}' dump1090-fa 2>/dev/null | grep -c "ok installed") == 1 ]]; then
+if is_package_installed "dump1090-fa"; then
     adsb_decoder_installed="true"
     chosen_adsb_decoder="dump1090-fa"
-    if [[ $(sudo dpkg -s dump1090-fa 2>/dev/null | grep -c "Version: ${dump1090_fa_current_version}") == 0 ]]; then
-        whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
-                 --title "FlightAware Dump1090 Upgrade Available" \
-                 --defaultno \
-                 --yesno "An updated version of FlightAware dump1090 is available.\n\nWould you like to install the new version?" \
-                 16 65
-        if [[ $? == 0 ]]; then
-            install_adsb_decoder="true"
-        fi
+    if [[ $(sudo dpkg -s dump1090-fa 2>/dev/null | grep -c "Version: ${dump1090_fa_current_version}") -eq 0 ]]; then
+        ask_reinstall "FlightAware Dump1090 Upgrade Available" \
+                      "An updated version of FlightAware dump1090 is available.\n\nWould you like to install the new version?" \
+                      16 65 install_adsb_decoder
     else
-        whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
-                 --title "Reinstall FlightAware dump1090" \
-                 --defaultno --yesno "The option to rebuild and reinstall FlightAware dump1090 is available.\n\nWould you like to rebuild and reinstall FlightAware dump1090?" \
-                 9 65
-        if [[ $? == 0 ]]; then
-            install_adsb_decoder="true"
-        fi
+        ask_reinstall "Reinstall FlightAware dump1090" \
+                      "The option to rebuild and reinstall FlightAware dump1090 is available.\n\nWould you like to rebuild and reinstall FlightAware dump1090?" \
+                      9 65 install_adsb_decoder
     fi
 fi
 
-if [[ $(dpkg-query -W -f='${STATUS}' readsb 2>/dev/null | grep -c "ok installed") == 1 ]]; then
+if is_package_installed "readsb"; then
     adsb_decoder_installed="true"
     chosen_adsb_decoder="readsb"
-    whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
-             --title "Reinstall Readsb Decoder" \
-             --defaultno \
-             --yesno "The option to rebuild and reinstall Readsb is available.\n\nWould you like to rebuild and reinstall Readsb?" \
-             9 65
-    if [[ $? == 0 ]]; then
-        install_adsb_decoder="true"
-    fi
+    ask_reinstall "Reinstall Readsb Decoder" \
+                  "The option to rebuild and reinstall Readsb is available.\n\nWould you like to rebuild and reinstall Readsb?" \
+                  9 65 install_adsb_decoder
 fi
 
 if [[ "${adsb_decoder_installed}" == "false" ]]; then
@@ -58,26 +69,10 @@ if [[ "${adsb_decoder_installed}" == "false" ]]; then
                                    "readsb" "Wiedehopf's detached fork of readsb." \
                                    3>&2 2>&1 1>&3)
     exit_status=$?
-    if [[ $exit_status != 0 || "${chosen_uat_decoder}" == "None" ]]; then
+    if [[ $exit_status -ne 0 || "${chosen_adsb_decoder}" == "None" ]]; then
         install_adsb_decoder="false"
     fi
 fi
-
-function install_dump1090_fa() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/decoders/dump1090-fa.sh
-    ${RECEIVER_BASH_DIRECTORY}/decoders/dump1090-fa.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
-
-function install_readsb() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/decoders/readsb.sh
-    ${RECEIVER_BASH_DIRECTORY}/decoders/readsb.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
 
 
 ## UAT DECODERS
@@ -85,25 +80,17 @@ function install_readsb() {
 uat_decoder_installed="false"
 install_uat_decoder="false"
 
-if [[ $(dpkg-query -W -f='${STATUS}' dump978-fa 2>/dev/null | grep -c "ok installed") == 1 ]]; then
+if is_package_installed "dump978-fa"; then
     uat_decoder_installed="true"
     chosen_uat_decoder="dump978-fa"
-    if [[ $(sudo dpkg -s dump978-fa 2>/dev/null | grep -c "Version: ${dump978_fa_current_version}") == 0 ]]; then
-        whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
-                 --title "FlightAware dump978 Upgrade Available" \
-                 --defaultno --yesno "An updated version of FlightAware dump978 is available.\n\nWould you like to install the new version?" \
-                 16 65
-        if [[ $? == 0 ]]; then
-            install_uat_decoder="true"
-        fi
+    if [[ $(sudo dpkg -s dump978-fa 2>/dev/null | grep -c "Version: ${dump978_fa_current_version}") -eq 0 ]]; then
+        ask_reinstall "FlightAware dump978 Upgrade Available" \
+                      "An updated version of FlightAware dump978 is available.\n\nWould you like to install the new version?" \
+                      16 65 install_uat_decoder
     else
-        whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
-                 --title "Reinstall FlightAware dump978" \
-                 --defaultno --yesno "The option to rebuild and reinstall FlightAware dump978 is available.\n\nWould you like to rebuild and reinstall FlightAware dump978?" \
-                 9 65
-        if [[ $? == 0 ]]; then
-            install_uat_decoder="true"
-        fi
+        ask_reinstall "Reinstall FlightAware dump978" \
+                      "The option to rebuild and reinstall FlightAware dump978 is available.\n\nWould you like to rebuild and reinstall FlightAware dump978?" \
+                      9 65 install_uat_decoder
     fi
 fi
 
@@ -117,18 +104,10 @@ if [[ "${uat_decoder_installed}" == "false" ]]; then
                                   "dump978-fa" "FlightAware's version of the dump978 decoder." \
                                   3>&2 2>&1 1>&3)
     exit_status=$?
-    if [[ $exit_status != 0 || "${chosen_uat_decoder}" == "None" ]]; then
+    if [[ $exit_status -ne 0 || "${chosen_uat_decoder}" == "None" ]]; then
         install_uat_decoder="false"
     fi
 fi
-
-function install_dump978_fa() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/decoders/dump978-fa.sh
-    ${RECEIVER_BASH_DIRECTORY}/decoders/dump978-fa.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
 
 
 ## ACARS DECODERS
@@ -139,14 +118,9 @@ install_acars_decoder="false"
 if [[ -f /etc/systemd/system/acarsdec.service ]]; then
     acars_decoder_installed="true"
     chosen_acars_decoder="acarsdec"
-    whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
-             --title "Reinstall ACARSDEC Decoder" \
-             --defaultno \
-             --yesno "The option to rebuild and reinstall ACARSDEC is available.\n\nWould you like to rebuild and reinstall ACARSDEC?" \
-             9 65
-    if [[ $? == 0 ]]; then
-        install_acars_decoder="true"
-    fi
+    ask_reinstall "Reinstall ACARSDEC Decoder" \
+                  "The option to rebuild and reinstall ACARSDEC is available.\n\nWould you like to rebuild and reinstall ACARSDEC?" \
+                  9 65 install_acars_decoder
 fi
 
 if [[ "${acars_decoder_installed}" == "false" ]]; then
@@ -159,18 +133,10 @@ if [[ "${acars_decoder_installed}" == "false" ]]; then
                                     "acarsdec" "Acarsdec is a multi-channels acars decoder." \
                                     3>&2 2>&1 1>&3)
     exit_status=$?
-    if [[ $exit_status != 0 || "${chosen_acars_decoder}" == "None" ]]; then
+    if [[ $exit_status -ne 0 || "${chosen_acars_decoder}" == "None" ]]; then
         install_acars_decoder="false"
     fi
 fi
-
-function install_acarsdec() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/decoders/acarsdec.sh
-    ${RECEIVER_BASH_DIRECTORY}/decoders/acarsdec.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
 
 
 ## VDL MODE 2 DECODERS
@@ -181,27 +147,17 @@ install_vdlm2_decoder="false"
 if [[ -f /etc/systemd/system/dumpvdl2.service ]]; then
     vdlm2_decoder_installed="true"
     chosen_vdlm2_decoder="dumpvdl2"
-    whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
-             --title "Reinstall dumpvdl2 Decoder" \
-             --defaultno \
-             --yesno "The option to rebuild and reinstall dumpvdl2 is available.\n\nWould you like to rebuild and reinstall dumpvdl2?" \
-             9 65
-    if [[ $? == 0 ]]; then
-        install_vdlm2_decoder="true"
-    fi
+    ask_reinstall "Reinstall dumpvdl2 Decoder" \
+                  "The option to rebuild and reinstall dumpvdl2 is available.\n\nWould you like to rebuild and reinstall dumpvdl2?" \
+                  9 65 install_vdlm2_decoder
 fi
 
 if [[ -f /etc/systemd/system/vdlm2dec.service ]]; then
     vdlm2_decoder_installed="true"
     chosen_vdlm2_decoder="vdlm2dec"
-    whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
-             --title "Reinstall VDLM2DEC Decoder" \
-             --defaultno \
-             --yesno "The option to rebuild and reinstall VDLM2DEC is available.\n\nWould you like to rebuild and reinstall VDLM2DEC?" \
-             9 65
-    if [[ $? == 0 ]]; then
-        install_vdlm2_decoder="true"
-    fi
+    ask_reinstall "Reinstall VDLM2DEC Decoder" \
+                  "The option to rebuild and reinstall VDLM2DEC is available.\n\nWould you like to rebuild and reinstall VDLM2DEC?" \
+                  9 65 install_vdlm2_decoder
 fi
 
 if [[ "${vdlm2_decoder_installed}" == "false" ]]; then
@@ -215,161 +171,96 @@ if [[ "${vdlm2_decoder_installed}" == "false" ]]; then
              "dumpvdl2" "dumpvdl2 is a VDL Mode 2 message decoder." \
              3>&2 2>&1 1>&3)
     exit_status=$?
-    if [[ $exit_status != 0 || "${chosen_vdlm2_decoder}" == "None" ]]; then
+    if [[ $exit_status -ne 0 || "${chosen_vdlm2_decoder}" == "None" ]]; then
         install_vdlm2_decoder="false"
     fi
 fi
 
-function install_dumpvdl2() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/decoders/dumpvdl2.sh
-    ${RECEIVER_BASH_DIRECTORY}/decoders/dumpvdl2.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
-
-function install_vdlm2dec() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/decoders/vdlm2dec.sh
-    ${RECEIVER_BASH_DIRECTORY}/decoders/vdlm2dec.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
-
 
 ## AGGREGATE SITE CLIENTS
 
-declare array feeder_list
-touch ${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES
+declare -a feeder_list
+touch "${RECEIVER_ROOT_DIRECTORY}/feeder_choices.txt"
 
 # ADS-B Exchange
 if [[ -f /lib/systemd/system/adsbexchange-mlat.service && -f /lib/systemd/system/adsbexchange-feed.service ]]; then
-    echo "ADS-B Exchange Feed Client (reinstall)" >> ${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES
+    echo "ADS-B Exchange Feed Client (reinstall)" >> "${RECEIVER_ROOT_DIRECTORY}/feeder_choices.txt"
     feeder_list=("${feeder_list[@]}" 'ADS-B Exchange Feed Client (reinstall/update)' '' OFF)
 else
-    echo "ADS-B Exchange Feed Client" >> ${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES
+    echo "ADS-B Exchange Feed Client" >> "${RECEIVER_ROOT_DIRECTORY}/feeder_choices.txt"
     feeder_list=("${feeder_list[@]}" 'ADS-B Exchange Feed Client' '' OFF)
 fi
 
-function install_adsbexchange_client() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/feeders/adsbexchange.sh
-    ${RECEIVER_BASH_DIRECTORY}/feeders/adsbexchange.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
 
 # AirNav Radar rbfeeder
-if [[ $(dpkg-query -W -f='${STATUS}' rbfeeder 2>/dev/null | grep -c "ok installed") == 0 ]]; then
+if ! is_package_installed "rbfeeder"; then
     feeder_list=("${feeder_list[@]}" 'AirNav Radar RBFeeder' '' OFF)
 else
-    echo "AirNav Radar RBFeeder (reinstall)" >> ${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES
+    echo "AirNav Radar RBFeeder (reinstall)" >> "${RECEIVER_ROOT_DIRECTORY}/feeder_choices.txt"
     feeder_list=("${feeder_list[@]}" 'AirNav Radar RBFeeder (reinstall/update)' '' OFF)
 fi
 
-function install_airnavradar_client() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/feeders/airnavradar.sh
-    ${RECEIVER_BASH_DIRECTORY}/feeders/airnavradar.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
 
 # Airplanes.live
 if [[ -f /lib/systemd/system/airplanes-feed.service && -f /lib/systemd/system/airplanes-mlat.service ]]; then
-    echo "Airplanes.live Feeder (reinstall)" >> ${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES
+    echo "Airplanes.live Feeder (reinstall)" >> "${RECEIVER_ROOT_DIRECTORY}/feeder_choices.txt"
     feeder_list=("${feeder_list[@]}" 'Airplanes.live Feeder (reinstall)' '' OFF)
 else
-    echo "Airplanes.live Feeder" >> ${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES
+    echo "Airplanes.live Feeder" >> "${RECEIVER_ROOT_DIRECTORY}/feeder_choices.txt"
     feeder_list=("${feeder_list[@]}" 'Airplanes.live Feeder' '' OFF)
 fi
 
-function install_airplaneslive_client() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/feeders/airplaneslive.sh
-    ${RECEIVER_BASH_DIRECTORY}/feeders/airplaneslive.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
 
 # FlightAware PiAware
-if [[ $(dpkg-query -W -f='${STATUS}' piaware 2>/dev/null | grep -c "ok installed") == 0 ]]; then
+if ! is_package_installed "piaware"; then
     feeder_list=("${feeder_list[@]}" 'FlightAware PiAware' '' OFF)
 else
-    if [[ $(sudo dpkg -s piaware 2>/dev/null | grep -c "Version: ${piaware_current_version}") == 0 ]]; then
+    if [[ $(sudo dpkg -s piaware 2>/dev/null | grep -c "Version: ${piaware_current_version}") -eq 0 ]]; then
         feeder_list=("${feeder_list[@]}" 'FlightAware PiAware (upgrade)' '' OFF)
     else
         feeder_list=("${feeder_list[@]}" 'FlightAware PiAware (reinstall)' '' OFF)
     fi
 fi
 
-function install_flightaware_client() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/feeders/piaware.sh
-    ${RECEIVER_BASH_DIRECTORY}/feeders/piaware.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
 
 # Flightradar24
-if [[ $(dpkg-query -W -f='${STATUS}' fr24feed 2>/dev/null | grep -c "ok installed") == 0 ]]; then
+if ! is_package_installed "fr24feed"; then
     feeder_list=("${feeder_list[@]}" 'Flightradar24 Client' '' OFF)
 else
-    if [[ $(sudo dpkg -s fr24feed 2>/dev/null | grep -c "Version: ${fr24feed_current_version}") == 0 ]]; then
+    if [[ $(sudo dpkg -s fr24feed 2>/dev/null | grep -c "Version: ${fr24feed_current_version}") -eq 0 ]]; then
         feeder_list=("${feeder_list[@]}" 'Flightradar24 Client (upgrade)' '' OFF)
     else
         feeder_list=("${feeder_list[@]}" 'Flightradar24 Client (reinstall)' '' OFF)
     fi
 fi
 
-function install_flightradar24_client() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/feeders/flightradar24.sh
-    ${RECEIVER_BASH_DIRECTORY}/feeders/flightradar24.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
 
 # Fly Italy ADS-B
 if [[ -f /lib/systemd/system/flyitalyadsb-mlat.service && -f /lib/systemd/system/flyitalyadsb-feed.service ]]; then
-    echo "Fly Italy ADS-B Feeder (upgrade)" >> ${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES
+    echo "Fly Italy ADS-B Feeder (upgrade)" >> "${RECEIVER_ROOT_DIRECTORY}/feeder_choices.txt"
     feeder_list=("${feeder_list[@]}" 'Fly Italy ADS-B Feeder (reinstall)' '' OFF)
 else
-    echo "Fly Italy ADS-B Feeder" >> ${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES
+    echo "Fly Italy ADS-B Feeder" >> "${RECEIVER_ROOT_DIRECTORY}/feeder_choices.txt"
     feeder_list=("${feeder_list[@]}" 'Fly Italy ADS-B Feeder' '' OFF)
 fi
 
-function install_flyitalyadsb_client() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/feeders/flyitalyadsb.sh
-    ${RECEIVER_BASH_DIRECTORY}/feeders/flyitalyadsb.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
 
 # OpenSky Network
-if [[ $(dpkg-query -W -f='${STATUS}' opensky-feeder 2>/dev/null | grep -c "ok installed") == 0 ]]; then
+if ! is_package_installed "opensky-feeder"; then
     feeder_list=("${feeder_list[@]}" 'OpenSky Network Feeder' '' OFF)
 else
-    if [[ $(sudo dpkg -s opensky-feeder 2>/dev/null | grep -c "Version: ${opensky_feeder_current_version}") == 0 ]]; then
+    if [[ $(sudo dpkg -s opensky-feeder 2>/dev/null | grep -c "Version: ${opensky_feeder_current_version}") -eq 0 ]]; then
         feeder_list=("${feeder_list[@]}" 'OpenSky Network Feeder (reinstall)' '' OFF)
     fi
 fi
 
-function install_openskynetwork_client() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/feeders/openskynetwork.sh
-    ${RECEIVER_BASH_DIRECTORY}/feeders/openskynetwork.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
 
 # Planefinder
-if [[ $(dpkg-query -W -f='${STATUS}' pfclient 2>/dev/null | grep -c "ok installed") == 0 ]]; then
+if ! is_package_installed "pfclient"; then
     feeder_list=("${feeder_list[@]}" 'Plane Finder Client' '' OFF)
 else
     pfclient_installed_version=$(sudo dpkg -s pfclient | grep Version | awk '{print $2}')
-    case "${CPU_ARCHITECTURE}" in
+    case "${RECEIVER_CPU_ARCHITECTURE}" in
         "armv7l"|"armv6l")
             if [[ "$pfclient_installed_version" != "${pfclient_current_version_armhf}" ]]; then
                 feeder_list=("${feeder_list[@]}" 'Plane Finder Client (upgrade)' '' OFF)
@@ -391,75 +282,41 @@ else
                 feeder_list=("${feeder_list[@]}" 'Plane Finder Client (reinstall)' '' OFF)
             fi
             ;;
-        "i386")
-            if [[ "$pfclient_installed_version" != "${pfclient_current_version_i386}" ]]; then
-                feeder_list=("${feeder_list[@]}" 'Plane Finder Client (upgrade)' '' OFF)
-            else
-                feeder_list=("${feeder_list[@]}" 'Plane Finder Client (reinstall)' '' OFF)
-            fi
-            ;;
         *)
             feeder_list=("${feeder_list[@]}" 'Plane Finder Client (reinstall)' '' OFF)
     esac
 fi
 
-function install_planefinder_client() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/feeders/planefinder.sh
-    ${RECEIVER_BASH_DIRECTORY}/feeders/planefinder.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
 
 whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
          --title "Client Installation Options" \
          --checklist \
          --nocancel \
          --separate-output "The following clients are available for installation.\nChoose the clients you wish to install." \
-         15 65 7 "${feeder_list[@]}" 2>${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES
+         15 65 7 "${feeder_list[@]}" 2>"${RECEIVER_ROOT_DIRECTORY}/feeder_choices.txt"
 
 
 ## PORTALS
 
 # ADS-B Portal
 install_portal="false"
-whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
-         --title "Install The ADS-B Portal" \
-         --defaultno \
-         --yesno "The ADS-B Portal is a web interface for your receiver. More information can be found in the ADS-B Receiver Project GitHub repository.\n\nhttps://github.com/jprochazka/adsb-receiver\n\nWould you like to install the ADS-B Portal?" \
-         12 78
-if [[ $? == 0 ]]; then
-    install_portal="true"
-fi
-
-function install_adsb_portal() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/portal/install.sh
-    ${RECEIVER_BASH_DIRECTORY}/portal/install.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
+ask_reinstall "Install The ADS-B Portal" \
+              "The ADS-B Portal is a web interface for your receiver. More information can be found in the ADS-B Receiver Project GitHub repository.\n\nhttps://github.com/jprochazka/adsb-receiver\n\nWould you like to install the ADS-B Portal?" \
+              12 78 install_portal
 
 
 ## Extras
 
-declare array extras_list
-touch ${RECEIVER_ROOT_DIRECTORY}/EXTRAS_CHOICES
+declare -a extras_list
+touch "${RECEIVER_ROOT_DIRECTORY}/extras_choices.txt"
 
 # Beast-splitter
-if [[ $(dpkg-query -W -f='${STATUS}' beast-splitter 2>/dev/null | grep -c "ok installed") == 0 ]]; then
+if ! is_package_installed "beast-splitter"; then
     extras_list=("${extras_list[@]}" 'beast-splitter' '' OFF)
 else
     extras_list=("${extras_list[@]}" 'beast-splitter (reinstall)' '' OFF)
 fi
 
-function install_beastsplitter() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/extras/beeastsplitter.sh
-    ${RECEIVER_BASH_DIRECTORY}/extras/beastsplitter.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
 
 # Duck DNS
 if [[ ! -f "${RECEIVER_BUILD_DIRECTORY}/duckdns/duck.sh" ]]; then
@@ -468,13 +325,6 @@ else
     extras_list=("${extras_list[@]}" 'Duck DNS Free Dynamic DNS Hosting (reinstall)' '' OFF)
 fi
 
-function install_duckdns() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/extras/duckdns.sh
-    ${RECEIVER_BASH_DIRECTORY}/extras/duckdns.sh
-    if [[ $? -ne 0 ]] ; then
-        exit 1
-    fi
-}
 
 # Graphs1090
 if [[ ! -f /lib/systemd/system/graphs1090.service ]]; then
@@ -483,13 +333,6 @@ else
     extras_list=("${extras_list[@]}" 'Graphs1090 (reinstall)' '' OFF)
 fi
 
-function install_graphs1090() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/extras/graphs1090.sh
-    ${RECEIVER_BASH_DIRECTORY}/extras/graphs1090.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
 
 # tar1090
 if [[ ! -f /lib/systemd/system/tar1090.service ]]; then
@@ -498,27 +341,20 @@ else
     extras_list=("${extras_list[@]}" 'tar1090 (reinstall)' '' OFF)
 fi
 
-function install_tar1090() {
-    chmod +x ${RECEIVER_BASH_DIRECTORY}/extras/tar1090.sh
-    ${RECEIVER_BASH_DIRECTORY}/extras/tar1090.sh
-    if [[ $? != 0 ]] ; then
-        exit 1
-    fi
-}
 
 whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
          --title "Extras Installation Options" \
          --checklist \
          --nocancel \
          --separate-output "The following extras are available for installation, please select any which you wish to install." \
-         11 65 4 "${extras_list[@]}" 2>${RECEIVER_ROOT_DIRECTORY}/EXTRAS_CHOICES
+         11 65 4 "${extras_list[@]}" 2>"${RECEIVER_ROOT_DIRECTORY}/extras_choices.txt"
 
 
 ## Setup Confirmation
 
-declare confirmation_message
+confirmation_message=""
 
-if [[ "${install_adsb_decoder}" == "false" && "${install_uat_decoder}" == "false" && "${install_acars_decoder}" == "false" && "${install_vdlm2_decoder}" == "false" && "${install_portal}" == "false" && ! -s "${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES" && ! -s "${RECEIVER_ROOT_DIRECTORY}/EXTRAS_CHOICES" ]]; then
+if [[ "${install_adsb_decoder}" == "false" && "${install_uat_decoder}" == "false" && "${install_acars_decoder}" == "false" && "${install_vdlm2_decoder}" == "false" && "${install_portal}" == "false" && ! -s "${RECEIVER_ROOT_DIRECTORY}/feeder_choices.txt" && ! -s "${RECEIVER_ROOT_DIRECTORY}/extras_choices.txt" ]]; then
     whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" \
              --title "Nothing to be done" \
              --msgbox "Nothing has been selected to be installed so the script will exit now." \
@@ -532,7 +368,7 @@ else
 
     # ADS-B decoders
     if [[ "${install_adsb_decoder}" == "true" ]]; then
-        case ${chosen_adsb_decoder} in
+        case "${chosen_adsb_decoder}" in
             "dump1090-fa")
                 confirmation_message="${confirmation_message}\n  * FlightAware dump1090"
                 ;;
@@ -543,8 +379,8 @@ else
     fi
 
     # UAT decoders
-    if [[ "${install_uat_decoder}" = "true" ]]; then
-        case ${chosen_uat_decoder} in
+    if [[ "${install_uat_decoder}" == "true" ]]; then
+        case "${chosen_uat_decoder}" in
             "dump978-fa")
                 confirmation_message="${confirmation_message}\n  * FlightAware dump978"
                 ;;
@@ -552,8 +388,8 @@ else
     fi
 
     # ACARS decoders
-    if [[ "${install_acars_decoder}" = "true" ]]; then
-        case ${chosen_acars_decoder} in
+    if [[ "${install_acars_decoder}" == "true" ]]; then
+        case "${chosen_acars_decoder}" in
             "acarsdec")
                 confirmation_message="${confirmation_message}\n  * ACARSDEC"
                 ;;
@@ -561,8 +397,8 @@ else
     fi
 
     # VDL Mode 2 decoders
-    if [[ "${install_vdlm2_decoder}" = "true" ]]; then
-        case ${chosen_vdlm2_decoder} in
+    if [[ "${install_vdlm2_decoder}" == "true" ]]; then
+        case "${chosen_vdlm2_decoder}" in
             "dumpvdl2")
                 confirmation_message="${confirmation_message}\n  * dumpvdl2"
                 ;;
@@ -572,12 +408,12 @@ else
         esac
     fi
 
-    # Aggragate site clients
-    if [[ -s "${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES" ]]; then
-        while read feeder_choice
+    # Aggregate site clients
+    if [[ -s "${RECEIVER_ROOT_DIRECTORY}/feeder_choices.txt" ]]; then
+        while IFS= read -r feeder_choice
         do
             confirmation_message="${confirmation_message}\n  * ${feeder_choice}"
-        done < ${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES
+        done < "${RECEIVER_ROOT_DIRECTORY}/feeder_choices.txt"
     fi
 
     # Portals
@@ -586,11 +422,11 @@ else
     fi
 
     # Extras
-    if [[ -s "${RECEIVER_ROOT_DIRECTORY}/EXTRAS_CHOICES" ]]; then
-        while read extra_choice
+    if [[ -s "${RECEIVER_ROOT_DIRECTORY}/extras_choices.txt" ]]; then
+        while IFS= read -r extra_choice
         do
             confirmation_message="${confirmation_message}\n  * ${extra_choice}"
-        done < ${RECEIVER_ROOT_DIRECTORY}/EXTRAS_CHOICES
+        done < "${RECEIVER_ROOT_DIRECTORY}/extras_choices.txt"
     fi
 
     confirmation_message="${confirmation_message}\n\n"
@@ -609,164 +445,104 @@ fi
 
 # ADS-B Decoders
 if [[ "${install_adsb_decoder}" == "true" ]]; then
-    case ${chosen_adsb_decoder} in
+    case "${chosen_adsb_decoder}" in
         "dump1090-fa")
-             install_dump1090_fa
+             run_installer "decoders/dump1090-fa.sh"
              ;;
         "readsb")
-             install_readsb
+             run_installer "decoders/readsb.sh"
              ;;
     esac
 fi
 
 # UAT Decoders
 if [[ "${install_uat_decoder}" == "true" ]]; then
-    case ${chosen_uat_decoder} in
+    case "${chosen_uat_decoder}" in
         "dump978-fa")
-             install_dump978_fa
+             run_installer "decoders/dump978-fa.sh"
              ;;
     esac
 fi
 
 # ACARS Decoders
 if [[ "${install_acars_decoder}" == "true" ]]; then
-    case ${chosen_acars_decoder} in
+    case "${chosen_acars_decoder}" in
         "acarsdec")
-             install_acarsdec
+             run_installer "decoders/acarsdec.sh"
              ;;
     esac
 fi
 
 # VDL Decoders
 if [[ "${install_vdlm2_decoder}" == "true" ]]; then
-    case ${chosen_vdlm2_decoder} in
+    case "${chosen_vdlm2_decoder}" in
         "dumpvdl2")
-            install_dumpvdl2
+            run_installer "decoders/dumpvdl2.sh"
             ;;
         "vdlm2dec")
-            install_vdlm2dec
+            run_installer "decoders/vdlm2dec.sh"
             ;;
     esac
 fi
 
-# Aggragate site clients
-run_adsbexchange_script="false"
-run_airnavradar_script="false"
-run_airplaneslive_script="false"
-run_flightaware_script="false"
-run_flightradar24_script="false"
-run_flyitalyadsb_script="false"
-run_openskynetwork_script="false"
-run_planefinder_script="false"
-
-if [[ -s "${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES" ]]; then
-    while read feeder_choice
+# Aggregate site clients
+if [[ -s "${RECEIVER_ROOT_DIRECTORY}/feeder_choices.txt" ]]; then
+    while IFS= read -r feeder_choice
     do
-        case ${feeder_choice} in
-            "ADS-B Exchange Feed Client"|"ADS-B Exchange Feed Client (reinstall/update)")
-                run_adsbexchange_script="true"
+        case "${feeder_choice}" in
+            "ADS-B Exchange Feed Client"*)
+                run_installer "feeders/adsbexchange.sh"
                 ;;
-            "AirNav Radar RBFeeder"|"AirNav Radar RBFeeder (reinstall/update)")
-                run_airnavradar_script="true"
+            "AirNav Radar RBFeeder"*)
+                run_installer "feeders/airnavradar.sh"
                 ;;
-            "Airplanes.live Feeder"|"Airplanes.live Feeder (reinstall)")
-                run_airplaneslive_script="true"
+            "Airplanes.live Feeder"*)
+                run_installer "feeders/airplaneslive.sh"
                 ;;
-            "FlightAware PiAware"|"FlightAware PiAware (upgrade)"|"FlightAware PiAware (reinstall)")
-                run_flightaware_script="true"
+            "FlightAware PiAware"*)
+                run_installer "feeders/piaware.sh"
                 ;;
-            "Flightradar24 Client"|"Flightradar24 Client (upgrade)"|"Flightradar24 Client (reinstall)")
-                run_flightradar24_script="true"
+            "Flightradar24 Client"*)
+                run_installer "feeders/flightradar24.sh"
                 ;;
-            "Fly Italy ADS-B Feeder"|"Fly Italy ADS-B Feeder (reinstall)")
-                run_flyitalyadsb_script="true"
+            "Fly Italy ADS-B Feeder"*)
+                run_installer "feeders/flyitalyadsb.sh"
                 ;;
-            "OpenSky Network Feeder"|"OpenSky Network Feeder (reinstall)")
-                run_openskynetwork_script="true"
+            "OpenSky Network Feeder"*)
+                run_installer "feeders/openskynetwork.sh"
                 ;;
-            "Plane Finder Client"|"Plane Finder Client (upgrade)"|"Plane Finder Client (reinstall)")
-                run_planefinder_script="true"
+            "Plane Finder Client"*)
+                run_installer "feeders/planefinder.sh"
                 ;;
         esac
-    done < ${RECEIVER_ROOT_DIRECTORY}/FEEDER_CHOICES
-fi
-
-if [[ "${run_adsbexchange_script}" == "true" ]]; then
-    install_adsbexchange_client
-fi
-
-if [[ "${run_airnavradar_script}" == "true" ]]; then
-    install_airnavradar_client
-fi
-
-if [[ "${run_airplaneslive_script}" == "true" ]]; then
-    install_airplaneslive_client
-fi
-
-if [[ "${run_flightaware_script}" == "true" ]]; then
-    install_flightaware_client
-fi
-
-if [[ "${run_flightradar24_script}" == "true" ]]; then
-    install_flightradar24_client
-fi
-
-if [[ "${run_flyitalyadsb_script}" == "true" ]]; then
-    install_flyitalyadsb_client
-fi
-
-if [[ "${run_openskynetwork_script}" == "true" ]]; then
-    install_openskynetwork_client
-fi
-
-if [[ "${run_planefinder_script}" == "true" ]]; then
-    install_planefinder_client
+    done < "${RECEIVER_ROOT_DIRECTORY}/feeder_choices.txt"
 fi
 
 # Portals
 if [[ "${install_portal}" == "true" ]]; then
-    install_adsb_portal
+    run_installer "portal/install.sh"
 fi
 
 # Extras
 
-run_beastsplitter_script="false"
-run_duckdns_script="false"
-
-if [[ -s "${RECEIVER_ROOT_DIRECTORY}/EXTRAS_CHOICES" ]]; then
-    while read extras_choice
+if [[ -s "${RECEIVER_ROOT_DIRECTORY}/extras_choices.txt" ]]; then
+    while IFS= read -r extras_choice
     do
-        case ${extras_choice} in
-            "beast-splitter"|"beast-splitter (reinstall)")
-                run_beastsplitter_script="true"
+        case "${extras_choice}" in
+            "beast-splitter"*)
+                run_installer "extras/beastsplitter.sh"
                 ;;
-            "Duck DNS Free Dynamic DNS Hosting"|"Duck DNS Free Dynamic DNS Hosting (reinstall)")
-                run_duckdns_script="true"
+            "Duck DNS Free Dynamic DNS Hosting"*)
+                run_installer "extras/duckdns.sh"
                 ;;
-            "Graphs1090"|"Graphs1090 (reinstall)")
-                run_graphs1090_script="true"
+            "Graphs1090"*)
+                run_installer "extras/graphs1090.sh"
                 ;;
-            "tar1090"|"tar1090 (reinstall)")
-                run_tar1090_script="true"
+            "tar1090"*)
+                run_installer "extras/tar1090.sh"
                 ;;
         esac
-    done < ${RECEIVER_ROOT_DIRECTORY}/EXTRAS_CHOICES
-fi
-
-if [[ "${run_beastsplitter_script}" == "true" ]]; then
-    install_beastsplitter
-fi
-
-if [[ "${run_duckdns_script}" == "true" ]]; then
-    install_duckdns
-fi
-
-if [[ "${run_graphs1090_script}" == "true" ]]; then
-    install_graphs1090
-fi
-
-if [[ "${run_tar1090_script}" == "true" ]]; then
-    install_tar1090
+    done < "${RECEIVER_ROOT_DIRECTORY}/extras_choices.txt"
 fi
 
 exit 0

--- a/bash/portal/install.sh
+++ b/bash/portal/install.sh
@@ -300,7 +300,6 @@ case $RECEIVER_OS_DISTRIBUTION in
         php_version=""
         ;;
     debian)
-        if [[ "${RECEIVER_OS_CODE_NAME}" == "bullseye" ]]; then php_version="7.4"; fi
         if [[ "${RECEIVER_OS_CODE_NAME}" == "bookworm" ]]; then php_version="8.2"; fi
         if [[ "${RECEIVER_OS_CODE_NAME}" == "trixie" ]]; then php_version="8.4"; fi
         ;;

--- a/bash/portal/install.sh
+++ b/bash/portal/install.sh
@@ -300,8 +300,9 @@ case $RECEIVER_OS_DISTRIBUTION in
         php_version=""
         ;;
     debian)
-        if [[ "${RECEIVER_OS_CODE_NAME}" == "bookworm" ]]; then php_version="8.2"; fi
         if [[ "${RECEIVER_OS_CODE_NAME}" == "bullseye" ]]; then php_version="7.4"; fi
+        if [[ "${RECEIVER_OS_CODE_NAME}" == "bookworm" ]]; then php_version="8.2"; fi
+        if [[ "${RECEIVER_OS_CODE_NAME}" == "trixie" ]]; then php_version="8.4"; fi
         ;;
 esac
 check_package php${php_version}-cgi

--- a/bash/tools/portal_backup.sh
+++ b/bash/tools/portal_backup.sh
@@ -2,13 +2,12 @@
 
 ## VARIABLES
 
-BACKUPDATE=$(date +"%Y-%m-%d-%H%M%S")
-RECEIVER_ROOT_DIRECTORY="${PWD}"
-BACKUPSDIRECTORY="${RECEIVER_ROOT_DIRECTORY}/backups"
-TEMPORARY_DIRECTORY="${RECEIVER_ROOT_DIRECTORY}/backup_${BACKUPDATE}"
-RAWDOCUMENTROOT=`/usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf -p | grep server.document-root`
-LIGHTTPDDOCUMENTROOT=`sed 's/.*"\(.*\)"[^"]*$/\1/' <<< ${RAWDOCUMENTROOT}`
-COLLECTD_RRD_DIRECTORY="/var/lib/collectd/rrd"
+backup_date=$(date +"%Y-%m-%d-%H%M%S")
+receiver_root_directory="${PWD}"
+backups_directory="${receiver_root_directory}/backups"
+temporary_directory="${receiver_root_directory}/backup_${backup_date}"
+lighttpd_document_root=$(/usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf -p | grep server.document-root | sed 's/.*"\(.*\)"[^"]*$/\1/')
+collectd_rrd_directory="/var/lib/collectd/rrd"
 
 
 ## BEGIN THE BACKUP PROCESS
@@ -27,83 +26,75 @@ echo -e ""
 ## PREPARE TO BEGIN CREATING BACKUPS
 
 echo -e "\e[94m  Declare the database engine being used...\e[97m"
-DATABASEENGINE=`grep 'db_driver' ${LIGHTTPDDOCUMENTROOT}/classes/settings.class.php | tail -n1 | cut -d\' -f2`
-echo -e "\e[94m  Declare whether or not the advanaced portal features were installed...\e[97m"
+database_engine=$(grep 'db_driver' "${lighttpd_document_root}/classes/settings.class.php" | tail -n1 | cut -d\' -f2)
 
-echo -e "\e[94m  Declare whether or not the advanaced portal features were installed...\e[97m"
-if [[ "${DATABASEENGINE}" = "xml" ]] ; then
-    ADVANCED=FALSE
-else
-    ADVANCED=TRUE
+if [[ "${database_engine}" == "sqlite" ]] ; then
+    database_path=$(grep 'db_host' "${lighttpd_document_root}/classes/settings.class.php" | tail -n1 | cut -d\' -f2)
 fi
 
-if [[ "${DATABASEENGINE}" = "sqlite" ]] ; then
-    DATABASEPATH=`grep 'db_host' ${LIGHTTPDDOCUMENTROOT}/classes/settings.class.php | tail -n1 | cut -d\' -f2`
+if [[ "${database_engine}" == "mysql" ]] ; then
+    mysql_database=$(grep 'db_database' "${lighttpd_document_root}/classes/settings.class.php" | tail -n1 | cut -d\' -f2)
+    mysql_username=$(grep 'db_username' "${lighttpd_document_root}/classes/settings.class.php" | tail -n1 | cut -d\' -f2)
+    mysql_password=$(grep 'db_password' "${lighttpd_document_root}/classes/settings.class.php" | tail -n1 | cut -d\' -f2)
 fi
 
-if [[ "${DATABASEENGINE}" = "mysql" ]] ; then
-    MYSQLDATABASE=`grep 'db_database' ${LIGHTTPDDOCUMENTROOT}/classes/settings.class.php | tail -n1 | cut -d\' -f2`
-    MYSQLUSERNAME=`grep 'db_username' ${LIGHTTPDDOCUMENTROOT}/classes/settings.class.php | tail -n1 | cut -d\' -f2`
-    MYSQLPASSWORD=`grep 'db_password' ${LIGHTTPDDOCUMENTROOT}/classes/settings.class.php | tail -n1 | cut -d\' -f2`
+echo -e "\e[94m  Checking that the directory ${backups_directory} exists...\e[97m"
+if [[ ! -d "${backups_directory}" ]] ; then
+    echo -e "\e[94m  Creating the directory ${backups_directory}...\e[97m"
+    mkdir -vp "${backups_directory}"
 fi
 
-echo -e "\e[94m  Checking that the directory ${BACKUPSDIRECTORY} exists...\e[97m"
-if [[ ! -d "${BACKUPSDIRECTORY}" ]] ; then
-    echo -e "\e[94m  Creating the directory ${BACKUPSDIRECTORY}...\e[97m"
-    mkdir -vp ${BACKUPSDIRECTORY}
-fi
-
-echo -e "\e[94m  Checking that the directory ${TEMPORARY_DIRECTORY} exists...\e[97m"
-if [[ ! -d "${TEMPORARY_DIRECTORY}" ]] ; then
-    echo -e "\e[94m  Creating the directory ${TEMPORARY_DIRECTORY}...\e[97m"
-    mkdir -vp ${TEMPORARY_DIRECTORY}
+echo -e "\e[94m  Checking that the directory ${temporary_directory} exists...\e[97m"
+if [[ ! -d "${temporary_directory}" ]] ; then
+    echo -e "\e[94m  Creating the directory ${temporary_directory}...\e[97m"
+    mkdir -vp "${temporary_directory}"
 fi
 
 
 ## BACKUP THE COLLECTD RRD FILES BY EXPORTING THEM TO XML.
 
-RRD_FILE_LIST=`find ${COLLECTD_RRD_DIRECTORY} -name '*.rrd'`
-if [[ -z "${RRD_FILE_LIST}" ]]; then
-    echo -e "\e[94m  No RRD file found in ${COLLECTD_RRD_DIRECTORY}...\e[97m"
+mapfile -t rrd_files < <(find "${collectd_rrd_directory}" -name '*.rrd')
+if [[ ${#rrd_files[@]} -eq 0 ]]; then
+    echo -e "\e[94m  No RRD file found in ${collectd_rrd_directory}...\e[97m"
     echo -e "\e[94m  Skipping RRD file backups...\e[97m"
 else
-    for RRD_FILE in `find ${COLLECTD_RRD_DIRECTORY} -name '*.rrd'`; do
-        echo -e "\e[94m  Exporting RRD files named $RRD_FILE to XML...\e[97m"
-        RRD_FILE_NAME=`basename -s .rrd $RRD_FILE`
-        RRD_FILE_DIRECTORY=`dirname $RRD_FILE`
-        if [ ! -d ${TEMPORARY_DIRECTORY}/${RRD_FILE_DIRECTORY} ]; then
-            mkdir ${TEMPORARY_DIRECTORY}/${RRD_FILE_DIRECTORY}
+    for rrd_file in "${rrd_files[@]}"; do
+        echo -e "\e[94m  Exporting RRD files named ${rrd_file} to XML...\e[97m"
+        rrd_file_name=$(basename -s .rrd "${rrd_file}")
+        rrd_file_directory=$(dirname "${rrd_file}")
+        if [[ ! -d "${temporary_directory}/${rrd_file_directory}" ]]; then
+            mkdir -p "${temporary_directory}/${rrd_file_directory}"
         fi
-        sudo rrdtool dump $RRD_FILE > ${TEMPORARY_DIRECTORY}/${RRD_FILE_DIRECTORY}/${RRD_FILE_NAME}.xml
+        sudo rrdtool dump "${rrd_file}" > "${temporary_directory}/${rrd_file_directory}/${rrd_file_name}.xml"
     done
 fi
 
 
 ## BACKUP PORTAL USING LITE FEATURES AND XML FILES
 
-if [[ "${ADVANCED}" = "FALSE" ]] ; then
-    echo -e "\e[94m  Checking that the directory ${TEMPORARY_DIRECTORY}/var/www/html/data/ exists...\e[97m"
-    if [[ ! -d "${TEMPORARY_DIRECTORY}/var/www/html/data/" ]] ; then
-        mkdir -vp ${TEMPORARY_DIRECTORY}/var/www/html/data/
+if [[ "${database_engine}" == "xml" ]] ; then
+    echo -e "\e[94m  Checking that the directory ${temporary_directory}/var/www/html/data/ exists...\e[97m"
+    if [[ ! -d "${temporary_directory}/var/www/html/data/" ]] ; then
+        mkdir -vp "${temporary_directory}/var/www/html/data/"
     fi
-    echo -e "\e[94m  Backing up all XML data files to ${TEMPORARY_DIRECTORY}/var/www/html/data/...\e[97m"
-    sudo cp -R /var/www/html/data/*.xml ${TEMPORARY_DIRECTORY}/var/www/html/data/
+    echo -e "\e[94m  Backing up all XML data files to ${temporary_directory}/var/www/html/data/...\e[97m"
+    sudo cp -R /var/www/html/data/*.xml "${temporary_directory}/var/www/html/data/"
 else
 
 
 ## BACKUP PORTAL USING ADVANCED FEATURES AND A SQLITE DATABASE
 
-    if [[ "${DATABASEENGINE}" = "sqlite" ]] ; then
-        echo -e "\e[94m  Backing up the SQLite database file to ${TEMPORARY_DIRECTORY}/var/www/html/data/portal.sqlite...\e[97m"
-        sudo cp -R ${DATABASEPATH} ${TEMPORARY_DIRECTORY}/var/www/html/data/portal.sqlite
+    if [[ "${database_engine}" == "sqlite" ]] ; then
+        echo -e "\e[94m  Backing up the SQLite database file to ${temporary_directory}/var/www/html/data/portal.sqlite...\e[97m"
+        sudo cp -R "${database_path}" "${temporary_directory}/var/www/html/data/portal.sqlite"
     fi
 
 
 ## BACKUP PORTAL USING ADVANCED FEATURES AND A MYSQL DATABASE
 
-    if [[ "${DATABASEENGINE}" = "mysql" ]] ; then
-        echo -e "\e[94m  Dumping the MySQL database ${MYSQLDATABASE} to the file ${TEMPORARY_DIRECTORY}/${MYSQLDATABASE}.sql...\e[97m"
-        mysqldump -u${MYSQLUSERNAME} -p${MYSQLPASSWORD} ${MYSQLDATABASE} > ${TEMPORARY_DIRECTORY}/${MYSQLDATABASE}.sql
+    if [[ "${database_engine}" == "mysql" ]] ; then
+        echo -e "\e[94m  Dumping the MySQL database ${mysql_database} to the file ${temporary_directory}/${mysql_database}.sql...\e[97m"
+        mysqldump -u"${mysql_username}" -p"${mysql_password}" "${mysql_database}" > "${temporary_directory}/${mysql_database}.sql"
     fi
 fi
 
@@ -111,10 +102,10 @@ fi
 
 echo -e "\e[94m  Compressing the backed up files...\e[97m"
 echo -e ""
-tar -zcvf ${BACKUPSDIRECTORY}/adsb-receiver_data_${BACKUPDATE}.tar.gz ${TEMPORARY_DIRECTORY}
+tar -zcvf "${backups_directory}/adsb-receiver_data_${backup_date}.tar.gz" "${temporary_directory}"
 echo -e ""
 echo -e "\e[94m  Removing the temporary backup directory...\e[97m"
-sudo rm -rf ${TEMPORARY_DIRECTORY}
+sudo rm -rf "${temporary_directory}"
 
 
 ## BACKUP PROCESS COMPLETE
@@ -123,14 +114,14 @@ echo -e "\e[32m"
 echo -e "  BACKUP PROCESS COMPLETE\e[93m"
 echo -e ""
 echo -e "  An archive containing the data just backed up can be found at:"
-echo -e "  ${TEMPORARY_DIRECTORY}/adsb-receiver_data_${BACKUPDATE}.tar.gz\e[97m"
+echo -e "  ${backups_directory}/adsb-receiver_data_${backup_date}.tar.gz\e[97m"
 echo -e ""
 
 echo -e "\e[93m  ------------------------------------------------------------------------------"
 echo -e "\e[92m  Finished backing up portal data.\e[39m"
 echo -e ""
-if [[ "${RECEIVER_AUTOMATED_INSTALL}" = "false" ]] ; then
-    read -p "Press enter to continue..." CONTINUE
+if [[ "${receiver_automated_install}" == "false" ]] ; then
+    read -r -p "Press enter to continue..." discard
 fi
 
 exit 0

--- a/bash/variables.sh
+++ b/bash/variables.sh
@@ -2,34 +2,33 @@
 
 ## DISPLAY COLORS
 
-display_default="\033[0m"
-display_heading="\033[1;36m"
-display_message="\033[2;36m"
-display_project_name="\033[1;31m"
-display_title_heading="\033[1;32m"
-display_title_message="\033[2;32m"
-display_warning_heading="\033[1;33m"
-display_warning_message="\033[2;33m"
-display_alert_heading="\033[1;31m"
-display_alert_message="\033[2;31m"
-display_false_inline="\033[2;31m"
-display_true_inline="\033[2;32m"
+readonly display_default="\033[0m"
+readonly display_heading="\033[1;36m"
+readonly display_message="\033[2;36m"
+readonly display_project_name="\033[1;31m"
+readonly display_title_heading="\033[1;32m"
+readonly display_title_message="\033[2;32m"
+readonly display_warning_heading="\033[1;33m"
+readonly display_warning_message="\033[2;33m"
+readonly display_alert_heading="\033[1;31m"
+readonly display_alert_message="\033[2;31m"
+readonly display_false_inline="\033[2;31m"
+readonly display_true_inline="\033[2;32m"
 
 ## SOFTWARE VERSIONS
 
 # FlightAware
-dump1090_fa_current_version="10.2"
-dump978_fa_current_version="10.2"
-piaware_current_version="10.2"
+readonly dump1090_fa_current_version="10.2"
+readonly dump978_fa_current_version="10.2"
+readonly piaware_current_version="10.2"
 
 # PlaneFinder Client
-pfclient_current_version_armhf="5.3.2"
-pfclient_current_version_arm64="5.3.2"
-pfclient_current_version_amd64="5.0.162"
-pfclient_current_version_i386="5.0.161"
+readonly pfclient_current_version_armhf="5.3.29"
+readonly pfclient_current_version_arm64="5.3.29"
+readonly pfclient_current_version_amd64="5.3.29"
 
 # Flightradar24 Client
-fr24feed_current_version="1.0.51-0"
+readonly fr24feed_current_version="1.0.54-0"
 
 # OpenSky Network Client
-opensky_feeder_current_version="2.1.7-1"
+readonly opensky_feeder_current_version="2.1.7-1"

--- a/build/portal/html/classes/template.class.php
+++ b/build/portal/html/classes/template.class.php
@@ -8,7 +8,7 @@
 
             // Check if the portal is installed or needs upgraded.
 
-            $thisVersion = "2.8.8";
+            $thisVersion = "2.8.10";
 
             if (!file_exists($_SERVER['DOCUMENT_ROOT']."/classes/settings.class.php")) {
                 header ("Location: /install/install.php");

--- a/build/portal/html/install/index.php
+++ b/build/portal/html/install/index.php
@@ -1,6 +1,6 @@
 <?php
     // The most current stable release.
-    $thisVersion = "2.8.8";
+    $thisVersion = "2.8.10";
 
     // Begin the upgrade process if this release is newer than what is installed.
     if (file_exists($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR."classes".DIRECTORY_SEPARATOR."settings.class.php")) {

--- a/build/portal/html/install/upgrade-v2.8.10.php
+++ b/build/portal/html/install/upgrade-v2.8.10.php
@@ -1,0 +1,37 @@
+<?php
+    ///////////////////////
+    // UPGRADE TO V2.8.10
+    ///////////////////////
+
+    // --------------------------------------------------------
+    // Updates the version to 2.8.10
+    // --------------------------------------------------------
+
+    $results = upgrade();
+    exit(json_encode($results));
+
+    function upgrade() {
+        require_once($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR."classes".DIRECTORY_SEPARATOR."common.class.php");
+        require_once($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR."classes".DIRECTORY_SEPARATOR."settings.class.php");
+
+        $common = new common();
+        $settings = new settings();
+
+        try {
+            // Update the version and patch settings
+            $common->updateSetting("version", "2.8.10");
+            $common->updateSetting("patch", "");
+
+            // The upgrade process completed successfully
+            $results['success'] = TRUE;
+            $results['message'] = "Upgrade to v2.8.10 successful.";
+            return $results;
+
+        } catch(Exception $e) {
+            // Something went wrong during this upgrade process
+            $results['success'] = FALSE;
+            $results['message'] = $e->getMessage();
+            return $results;
+        }
+    }
+?>

--- a/build/portal/html/install/upgrade-v2.8.9.php
+++ b/build/portal/html/install/upgrade-v2.8.9.php
@@ -1,0 +1,37 @@
+<?php
+    ///////////////////////
+    // UPGRADE TO V2.8.9
+    ///////////////////////
+
+    // --------------------------------------------------------
+    // Updates the version to 2.8.9
+    // --------------------------------------------------------
+
+    $results = upgrade();
+    exit(json_encode($results));
+
+    function upgrade() {
+        require_once($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR."classes".DIRECTORY_SEPARATOR."common.class.php");
+        require_once($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR."classes".DIRECTORY_SEPARATOR."settings.class.php");
+
+        $common = new common();
+        $settings = new settings();
+
+        try {
+            // Update the version and patch settings
+            $common->updateSetting("version", "2.8.9");
+            $common->updateSetting("patch", "");
+
+            // The upgrade process completed successfully
+            $results['success'] = TRUE;
+            $results['message'] = "Upgrade to v2.8.9 successful.";
+            return $results;
+
+        } catch(Exception $e) {
+            // Something went wrong during this upgrade process
+            $results['success'] = FALSE;
+            $results['message'] = $e->getMessage();
+            return $results;
+        }
+    }
+?>

--- a/build/portal/html/install/upgrade.php
+++ b/build/portal/html/install/upgrade.php
@@ -4,7 +4,7 @@
     $common = new common();
 
     // The most current stable release.
-    $thisVersion = "2.8.8";
+    $thisVersion = "2.8.10";
 
     // Begin the upgrade process if this release is newer than what is installed.
     if ($common->getSetting("version") == $thisVersion) {
@@ -227,6 +227,24 @@
         $success = $results['success'];
         $message = $results['message'];
         $version = "2.8.8";
+    }
+
+    // UPGRADE TO V2.8.9
+    if ($common->getSetting("version") == "2.8.8" && $success) {
+        $json = file_get_contents("http://localhost/install/upgrade-v2.8.9.php");
+        $results = json_decode($json, TRUE);
+        $success = $results['success'];
+        $message = $results['message'];
+        $version = "2.8.9";
+    }
+
+    // UPGRADE TO V2.8.10
+    if ($common->getSetting("version") == "2.8.9" && $success) {
+        $json = file_get_contents("http://localhost/install/upgrade-v2.8.10.php");
+        $results = json_decode($json, TRUE);
+        $success = $results['success'];
+        $message = $results['message'];
+        $version = "2.8.10";
     }
 
     require_once($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR."admin".DIRECTORY_SEPARATOR."includes".DIRECTORY_SEPARATOR."header.inc.php");

--- a/install.sh
+++ b/install.sh
@@ -1,19 +1,21 @@
 #!/bin/bash
 
-## ASSIGN VARIABLE
+## ASSIGN VARIABLES
 
-project_version="2.8.9"
+project_version="2.8.10"
 
 printf -v date_time '%(%Y-%m-%d_%H-%M-%S)T' -1
 log_file="adsb-installer_${date_time}.log"
 logging_enabled="true"
 project_branch="master"
+development_mode=""
+mta=""
 
 
 ## FUNCTIONS
 
 # Display the help message
-function DisplayHelp() {
+function display_help() {
     echo "                                                                                           "
     echo "Usage: $0 [OPTION] [ARGUMENT]                                                              "
     echo "                                                                                           "
@@ -33,87 +35,88 @@ function DisplayHelp() {
 
 ## CHECK FOR OPTIONS AND ARGUMENTS
 
-while [[ $# > 0 ]] ; do
-    case $1 in
-        --branch*)
-            project_branch=`echo $1 | sed -e 's/^[^=]*=//g'`
-            shift 1
+# Normalize long options to short equivalents for getopts
+if [[ $# -gt 0 ]]; then
+    normalized_args=()
+    for arg in "$@"; do
+        case "$arg" in
+            --branch=*)    normalized_args+=("-b" "${arg#*=}") ;;
+            --development) normalized_args+=("-d") ;;
+            --help)        normalized_args+=("-h") ;;
+            --mta=*)       normalized_args+=("-m" "${arg#*=}") ;;
+            --no-logging)  normalized_args+=("-n") ;;
+            --version)     normalized_args+=("-v") ;;
+            *)             normalized_args+=("$arg") ;;
+        esac
+    done
+    set -- "${normalized_args[@]}"
+fi
+
+while getopts ":b:dhm:nv" opt; do
+    case "$opt" in
+        b)
+            project_branch="$OPTARG"
             ;;
-        -b)
-            project_branch=$2
-            shift 2
-            ;;
-        --development | -d)
+        d)
             development_mode="true"
-            shift 1
             ;;
-        --help | -h)
-            DisplayHelp
+        h)
+            display_help
             exit 0
             ;;
-        --mta*)
-            mta=`echo ${1^^} | sed -e 's/^[^=]*=//g'`
+        m)
+            mta="${OPTARG^^}"
             if [[ "${mta}" != "EXIM" && "${mta}" != "POSTFIX" ]]; then
                 echo "MTA can only be either EXIM or POSTFIX."
                 exit 1
             fi
-            shift 1
             ;;
-        --no-logging | -n)
+        n)
             logging_enabled="false"
-            shift 1
             ;;
-        -m)
-           # The MTA to use
-            mta=${2^^}
-            if [[ "${mta}" != "EXIM" && "${mta}" != "POSTFIX" ]]; then
-                echo "MTA can only be either EXIM or POSTFIX."
-                exit 1
-            fi
-            shift 2
-            ;;
-        --version | -v)
-            # Display the version
-            echo $project_version
+        v)
+            echo "$project_version"
             exit 0
             ;;
-        *)
-            # Unknown options were set so exit
-            echo -e "Error: Unknown option: $1" >&2
-            DisplayHelp
+        :)
+            echo "Error: Option -${OPTARG} requires an argument." >&2
+            display_help
+            exit 1
+            ;;
+        \?)
+            echo "Error: Unknown option: -${OPTARG}" >&2
+            display_help
             exit 1
             ;;
     esac
 done
 
-export RECEIVER_PROJECT_BRANCH=$project_branch
-export RECEIVER_DEVELOPMENT_MODE=$development_mode
-export RECEIVER_LOGGING_ENABLED=$logging_enabled
-export RECEIVER_MTA=$mta
+export RECEIVER_PROJECT_BRANCH="${project_branch}"
+export RECEIVER_DEVELOPMENT_MODE="${development_mode}"
+export RECEIVER_LOGGING_ENABLED="${logging_enabled}"
+export RECEIVER_MTA="${mta}"
 
 
 ## SET PROJECT VARIABLES
 
 export RECEIVER_PROJECT_TITLE="ADS-B Receiver Installer v${project_version}"
-export RECEIVER_ROOT_DIRECTORY=$PWD
-export RECEIVER_BASH_DIRECTORY=$PWD/bash
-export RECEIVER_BUILD_DIRECTORY=$PWD/build
+export RECEIVER_ROOT_DIRECTORY="${PWD}"
+export RECEIVER_BASH_DIRECTORY="${PWD}/bash"
+export RECEIVER_BUILD_DIRECTORY="${PWD}/build"
 
 
 ## SOURCE EXTERNAL SCRIPTS
 
-source $RECEIVER_BASH_DIRECTORY/functions.sh
-source $RECEIVER_BASH_DIRECTORY/variables.sh
+source "${RECEIVER_BASH_DIRECTORY}/functions.sh"
+source "${RECEIVER_BASH_DIRECTORY}/variables.sh"
 
 
 ## CREATE THE LOG DIRECTORY
 
 if [[ "${RECEIVER_LOGGING_ENABLED}" == "true" ]]; then
-    export RECEIVER_LOG_FILE=$PWD/logs/$log_file
-    if [ ! -d "$DIRECTORY" ]; then
-        log_message "Creating logs directory"
-        mkdir $PWD/logs
-    fi
+    export RECEIVER_LOG_FILE="${PWD}/logs/${log_file}"
+    mkdir -p "${PWD}/logs"
+    log_message "Creating logs directory"
 fi
 
 
@@ -128,7 +131,7 @@ log_heading "Updating package lists for all enabled repositories and PPAs"
 
 log_message "Downloading the latest package lists for all enabled repositories and PPAs"
 echo ""
-sudo apt-get update 2>&1 | tee -a $RECEIVER_LOG_FILE
+sudo apt-get update 2>&1 | log_pipe
 
 log_heading "Ensuring that all required packages are installed"
 
@@ -142,20 +145,28 @@ echo ""
 log_title_message "------------------------------------------------------------------------------"
 log_title_heading "ADS-B Receiver Installer package dependency check complete"
 echo ""
-read -p "Press enter to continue..." discard
+if [[ -t 0 ]]; then
+    read -r -p "Press enter to continue..." discard
+fi
 
 
 ## SET OS VARIABLES
 
-export RECEIVER_OS_CODE_NAME=`lsb_release -c -s`
-export RECEIVER_OS_DISTRIBUTION=`. /etc/os-release; echo ${ID/*, /}`
-export RECEIVER_OS_RELEASE=`. /etc/os-release; echo ${VERSION_ID/*, /}`
+RECEIVER_OS_CODE_NAME=$(lsb_release -c -s)
+export RECEIVER_OS_CODE_NAME
+RECEIVER_OS_DISTRIBUTION=$(. /etc/os-release; echo "${ID/*, /}")
+export RECEIVER_OS_DISTRIBUTION
+RECEIVER_OS_RELEASE=$(. /etc/os-release; echo "${VERSION_ID/*, /}")
+export RECEIVER_OS_RELEASE
 
 
-## SET HANDWARE VARIABLES
+## SET HARDWARE VARIABLES
 
-export RECIEVER_CPU_ARCHITECTURE=`uname -m | tr -d "\n\r"`
-export RECEIVER_CPU_REVISION=`grep "^Revision" /proc/cpuinfo | awk '{print $3}'`
+RECEIVER_CPU_ARCHITECTURE=$(uname -m | tr -d "\n\r")
+export RECEIVER_CPU_ARCHITECTURE
+RECEIVER_CPU_REVISION=$(grep "^Revision" /proc/cpuinfo | awk '{print $3}')
+export RECEIVER_CPU_REVISION
+
 
 ## INIT DECODER DEVICE ASSIGNMENT VARIABLES
 
@@ -171,16 +182,14 @@ export RECEIVER_VDLM2_DECODER_SOFTWARE
 
 ## EXECUTE BASH/INIT.SH
 
-chmod +x $RECEIVER_BASH_DIRECTORY/init.sh
-$RECEIVER_BASH_DIRECTORY/init.sh
+bash "${RECEIVER_BASH_DIRECTORY}/init.sh"
+init_exit_code=$?
 
 
 ## CLEAN UP
 
-for choice in FEEDER_CHOICES EXTRAS_CHOICES ; do
-    if [[ -f ${RECEIVER_ROOT_DIRECTORY}/${choice} ]] ; then
-        rm -f ${RECEIVER_ROOT_DIRECTORY}/${choice}
-    fi
+for choice in feeder_choices.txt extras_choices.txt ; do
+    rm -f "${RECEIVER_ROOT_DIRECTORY}/${choice}"
 done
 
 unset RECEIVER_PROJECT_TITLE
@@ -190,7 +199,7 @@ unset RECEIVER_BUILD_DIRECTORY
 unset RECEIVER_OS_CODE_NAME
 unset RECEIVER_OS_DISTRIBUTION
 unset RECEIVER_OS_RELEASE
-unset RECIEVER_CPU_ARCHITECTURE
+unset RECEIVER_CPU_ARCHITECTURE
 unset RECEIVER_CPU_REVISION
 unset RECEIVER_DEVICE_ASSIGNED_TO_ACARS_DECODER
 unset RECEIVER_DEVICE_ASSIGNED_TO_ADSB_DECODER
@@ -206,9 +215,4 @@ unset RECEIVER_LOGGING_ENABLED
 unset RECEIVER_LOG_FILE
 unset RECEIVER_MTA
 
-# Check if any errors were encountered by any child scripts
-if [[ $? != 0 ]] ; then
-    exit 1
-else
-    exit 0
-fi
+exit "$init_exit_code"


### PR DESCRIPTION
v2.8.10 

* Removed support for Debian Bullseye.
* Trixie, Noble and Questing uses the official piaware_builder dev branch.
* Correct Ubuntu versions are associated with matching Debian version.
* Specify correct versions of PHP for Noble and Questing.
* Check for the rsyslog package before installing PiAware.
* Refactored core bash scripts.
* The no logging parameter option is now respected.
* Correct install script is used when BeastSpliter is selected.
* Correct CPU architecture is used to pick Plane Finder client.
* Update Flightradar24 client version.
* Updated Plane Finder ADS-B client versions.
* Removed i386 Plane Finder ADS-B client option.